### PR TITLE
[BOUNTY #7] Adzuna Jobs API scraper (multi-country)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@
 NERAJOB_USER_AGENT=NeraJob/0.1 (+https://github.com/mergeos-bounties/NeraJob)
 NERAJOB_HTTP_TIMEOUT=20
 NERAJOB_DATA_DIR=data
+
+# Adzuna Jobs API — free keys at https://developer.adzuna.com/
+# ADZUNA_APP_ID=your_app_id
+# ADZUNA_APP_KEY=your_app_key
+# NERAJOB_ADZUNA_COUNTRY=us  # us, gb, de, au, in, ca, fr, etc.

--- a/src/nerajob/scrapers/adzuna.py
+++ b/src/nerajob/scrapers/adzuna.py
@@ -1,0 +1,168 @@
+"""Adzuna Jobs API scraper with multi-country support.
+
+Requirements:
+- Env: ADZUNA_APP_ID, ADZUNA_APP_KEY
+- CLI: --country flag (us, gb, de, au, in, etc.)
+- Tests: mock HTTP responses for 2+ countries
+- Docs: free developer signup guide
+
+Source: https://developer.adzuna.com/
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import ClassVar
+from urllib.error import URLError
+from urllib.parse import quote_plus
+from urllib.request import Request, urlopen
+
+from nerajob.config import http_timeout, user_agent
+from nerajob.models import JobPosting, to_iso_date_str
+from nerajob.scrapers.base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+# ISO 3166-1 alpha-2 → Adzuna country code mapping
+# https://developer.adzuna.com/activedocs#!/adzuna/search
+_COUNTRY_MAP: dict[str, str] = {
+    "us": "us", "gb": "gb", "de": "de", "au": "au",
+    "in": "in", "ca": "ca", "fr": "fr", "nl": "nl",
+    "br": "br", "ru": "ru", "za": "za", "pl": "pl",
+    "sg": "sg", "it": "it", "es": "es", "mx": "mx",
+    "at": "at", "be": "be", "ch": "ch", "se": "se",
+    "no": "no", "nz": "nz", "ie": "ie", "pt": "pt",
+    "ae": "ae", "hk": "hk", "my": "my", "ph": "ph",
+    "th": "th", "vn": "vn", "id": "id", "jp": "jp",
+    "kr": "kr", "tr": "tr", "eg": "eg", "ng": "ng",
+    "ke": "ke", "gh": "gh", "ma": "ma", "ar": "ar",
+    "cl": "cl", "pe": "pe", "co": "co", "ve": "ve",
+}
+
+_ADZUNA_BASE = "https://api.adzuna.com/v1/api/jobs"
+
+
+class AdzunaScraper(BaseScraper):
+    """Scraper for Adzuna Jobs API.
+
+    Sign up for free at https://developer.adzuna.com/ to get:
+    - ADZUNA_APP_ID
+    - ADZUNA_APP_KEY
+    """
+
+    name: ClassVar[str] = "adzuna"
+
+    def __init__(self, country: str = "us"):
+        self._country = self._normalize_country(country)
+        self._app_id = os.getenv("ADZUNA_APP_ID", "")
+        self._app_key = os.getenv("ADZUNA_APP_KEY", "")
+
+    @staticmethod
+    def _normalize_country(country: str) -> str:
+        c = country.strip().lower()
+        if c in _COUNTRY_MAP:
+            return c
+        raise ValueError(
+            f"Unsupported country: {country}. "
+            f"Supported: {', '.join(sorted(_COUNTRY_MAP))}"
+        )
+
+    @property
+    def country(self) -> str:
+        return self._country
+
+    @property
+    def _has_credentials(self) -> bool:
+        return bool(self._app_id) and bool(self._app_key)
+
+    def _build_url(
+        self, query: str, location: str = "", page: int = 1, results_per_page: int = 20
+    ) -> str:
+        """Build Adzuna API search URL."""
+        what = quote_plus(query)
+        where = quote_plus(location) if location else ""
+        return (
+            f"{_ADZUNA_BASE}/{self._country}/search/{page}"
+            f"?app_id={self._app_id}&app_key={self._app_key}"
+            f"&results_per_page={min(results_per_page, 50)}"
+            f"&what={what}"
+            f"{'&where=' + where if where else ''}"
+            f"&content-type=application/json"
+        )
+
+    def _parse_job(self, raw: dict) -> JobPosting:
+        """Parse a single Adzuna API result into a JobPosting."""
+        created = raw.get("created", "")
+        try:
+            date_posted = to_iso_date_str(created) if created else ""
+        except Exception:
+            date_posted = created
+
+        return JobPosting(
+            id=f"adzuna-{self._country}-{raw.get('id', '')}",
+            title=raw.get("title", "Untitled"),
+            company=raw.get("company", {}).get("display_name", "Unknown"),
+            location=raw.get("location", {}).get("display_name", ""),
+            description=raw.get("description", "")[:5000],
+            url=raw.get("redirect_url", ""),
+            source=self.name,
+            salary_min=raw.get("salary_min"),
+            salary_max=raw.get("salary_max"),
+            salary_currency=raw.get("salary_currency"),
+            contract_type=raw.get("contract_type", ""),
+            date_posted=date_posted,
+        )
+
+    def search(
+        self, query: str, location: str = "", limit: int = 20
+    ) -> list[JobPosting]:
+        """Search Adzuna Jobs API.
+
+        Args:
+            query: Search keywords (e.g., "python developer").
+            location: City/region filter (empty = nationwide).
+            limit: Max results to return (per-page capped at 50).
+
+        Returns:
+            List of JobPosting objects, or empty list on error.
+        """
+        if not self._has_credentials:
+            logger.warning(
+                "Adzuna: ADZUNA_APP_ID / ADZUNA_APP_KEY not set. "
+                "Get free keys at https://developer.adzuna.com/"
+            )
+            return []
+
+        results: list[JobPosting] = []
+        page = 1
+        per_page = min(limit, 50)
+
+        while len(results) < limit:
+            url = self._build_url(query, location, page, per_page)
+            try:
+                req = Request(url, headers={"User-Agent": user_agent()})
+                with urlopen(req, timeout=http_timeout()) as resp:  # noqa: S310
+                    data = __import__("json").loads(resp.read())
+            except (URLError, TimeoutError, OSError, Exception) as e:
+                logger.warning("Adzuna API error: %s", e)
+                break
+            except ImportError:
+                logger.warning("Adzuna: json module unavailable")
+                break
+
+            hits = data.get("results", [])
+            if not hits:
+                break
+
+            for hit in hits:
+                try:
+                    results.append(self._parse_job(hit))
+                except Exception:
+                    logger.debug("Skipped malformed Adzuna result", exc_info=True)
+
+            if len(hits) < per_page:
+                break
+            page += 1
+
+        return results[:limit]

--- a/src/nerajob/scrapers/registry.py
+++ b/src/nerajob/scrapers/registry.py
@@ -12,6 +12,7 @@ from nerajob.scrapers.remotive import RemotiveScraper
 from nerajob.scrapers.sample import SampleScraper
 from nerajob.scrapers.smartrecruiters import SmartRecruitersScraper
 from nerajob.scrapers.themuse import TheMuseScraper
+from nerajob.scrapers.adzuna import AdzunaScraper
 from nerajob.scrapers.weworkremotely import WeWorkRemotelyScraper
 
 
@@ -41,6 +42,7 @@ def available_scrapers() -> dict[str, BaseScraper]:
         LeverScraper(board_name=os.getenv("NERAJOB_LEVER_BOARD") or None),
         AshbyScraper(board_id=os.getenv("NERAJOB_ASHBY_BOARD") or None),
         SmartRecruitersScraper(),
+        AdzunaScraper(country=os.getenv("NERAJOB_ADZUNA_COUNTRY", "us")),
     ]
     return {s.name: s for s in scrapers}
 

--- a/tests/test_adzuna.py
+++ b/tests/test_adzuna.py
@@ -1,0 +1,303 @@
+"""Tests for Adzuna Jobs API scraper with mock HTTP responses."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nerajob.scrapers.adzuna import AdzunaScraper, _COUNTRY_MAP
+
+
+@pytest.fixture
+def clear_env():
+    keys = ["ADZUNA_APP_ID", "ADZUNA_APP_KEY", "NERAJOB_ADZUNA_COUNTRY"]
+    saved = {k: os.environ.pop(k, None) for k in keys}
+    yield
+    for k, v in saved.items():
+        if v is not None:
+            os.environ[k] = v
+        else:
+            os.environ.pop(k, None)
+
+
+class TestAdzunaCountryMapping:
+    def test_supported_countries(self):
+        assert "us" in _COUNTRY_MAP
+        assert "gb" in _COUNTRY_MAP
+        assert "de" in _COUNTRY_MAP
+        assert "au" in _COUNTRY_MAP
+        assert "in" in _COUNTRY_MAP
+
+    def test_country_count(self):
+        assert len(_COUNTRY_MAP) >= 40
+
+    def test_normalize_country(self):
+        assert AdzunaScraper._normalize_country("US") == "us"
+        assert AdzunaScraper._normalize_country("  GB  ") == "gb"
+
+    def test_unsupported_country_raises(self):
+        with pytest.raises(ValueError, match="Unsupported country"):
+            AdzunaScraper._normalize_country("zz")
+
+    def test_default_country_is_us(self):
+        scraper = AdzunaScraper()
+        assert scraper.country == "us"
+
+
+class TestAdzunaScraper:
+    def test_name(self):
+        assert AdzunaScraper().name == "adzuna"
+
+    def test_no_credentials_returns_empty(self, clear_env):
+        scraper = AdzunaScraper()
+        result = scraper.search("python")
+        assert result == []
+
+    def test_no_credentials_logs_warning(self, clear_env, caplog):
+        import logging
+        caplog.set_level(logging.WARNING)
+        scraper = AdzunaScraper()
+        scraper.search("python")
+        assert "ADZUNA_APP_ID" in caplog.text
+
+
+class TestAdzunaMockAPI:
+    @patch("nerajob.scrapers.adzuna.urlopen")
+    def test_search_us(self, mock_urlopen, clear_env):
+        os.environ["ADZUNA_APP_ID"] = "test_id"
+        os.environ["ADZUNA_APP_KEY"] = "test_key"
+        os.environ["NERAJOB_ADZUNA_COUNTRY"] = "us"
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({
+            "results": [
+                {
+                    "id": "12345",
+                    "title": "Python Developer",
+                    "company": {"display_name": "TechCorp"},
+                    "location": {"display_name": "San Francisco"},
+                    "description": "Build awesome Python apps",
+                    "redirect_url": "https://example.com/job/1",
+                    "salary_min": 120000,
+                    "salary_max": 160000,
+                    "salary_currency": "USD",
+                    "contract_type": "permanent",
+                    "created": "2026-07-10T10:00:00Z",
+                },
+                {
+                    "id": "67890",
+                    "title": "Senior Backend Engineer",
+                    "company": {"display_name": "StartupX"},
+                    "location": {"display_name": "Remote"},
+                    "description": "Scalable systems",
+                    "redirect_url": "https://example.com/job/2",
+                    "salary_min": 140000,
+                    "salary_max": 180000,
+                    "salary_currency": "USD",
+                    "contract_type": "permanent",
+                    "created": "2026-07-09T10:00:00Z",
+                },
+            ]
+        }).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+        scraper = AdzunaScraper(country="us")
+        result = scraper.search("python", limit=20)
+
+        assert len(result) == 2
+        assert result[0].title == "Python Developer"
+        assert result[0].company == "TechCorp"
+        assert result[0].salary_min == 120000
+        assert result[0].salary_currency == "USD"
+        assert result[0].source == "adzuna"
+        assert result[1].title == "Senior Backend Engineer"
+        assert result[1].company == "StartupX"
+
+    @patch("nerajob.scrapers.adzuna.urlopen")
+    def test_search_gb(self, mock_urlopen, clear_env):
+        os.environ["ADZUNA_APP_ID"] = "test_id"
+        os.environ["ADZUNA_APP_KEY"] = "test_key"
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({
+            "results": [
+                {
+                    "id": "111",
+                    "title": "Software Engineer",
+                    "company": {"display_name": "London FinTech"},
+                    "location": {"display_name": "London"},
+                    "description": "FinTech platform",
+                    "redirect_url": "https://example.com/job/3",
+                    "salary_min": 50000,
+                    "salary_max": 70000,
+                    "salary_currency": "GBP",
+                    "contract_type": "permanent",
+                    "created": "2026-07-10T10:00:00Z",
+                },
+            ]
+        }).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+        scraper = AdzunaScraper(country="gb")
+        result = scraper.search("engineer", limit=20)
+
+        assert len(result) == 1
+        assert result[0].company == "London FinTech"
+        assert result[0].salary_currency == "GBP"
+        assert result[0].location == "London"
+        assert "adzuna-gb" in result[0].id
+
+    @patch("nerajob.scrapers.adzuna.urlopen")
+    def test_search_de(self, mock_urlopen, clear_env):
+        os.environ["ADZUNA_APP_ID"] = "test_id"
+        os.environ["ADZUNA_APP_KEY"] = "test_key"
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({
+            "results": [
+                {
+                    "id": "222",
+                    "title": "Entwickler",
+                    "company": {"display_name": "BerlinTech"},
+                    "location": {"display_name": "Berlin"},
+                    "description": "Python Entwicklung",
+                    "redirect_url": "https://example.com/job/4",
+                    "salary_min": 60000,
+                    "salary_max": 80000,
+                    "salary_currency": "EUR",
+                    "contract_type": "permanent",
+                    "created": "2026-07-10T10:00:00Z",
+                },
+            ]
+        }).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+        scraper = AdzunaScraper(country="de")
+        result = scraper.search("python", limit=20)
+
+        assert len(result) == 1
+        assert result[0].salary_currency == "EUR"
+        assert "adzuna-de" in result[0].id
+
+    @patch("nerajob.scrapers.adzuna.urlopen")
+    def test_search_empty_results(self, mock_urlopen, clear_env):
+        os.environ["ADZUNA_APP_ID"] = "test_id"
+        os.environ["ADZUNA_APP_KEY"] = "test_key"
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"results": []}).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+        scraper = AdzunaScraper(country="us")
+        result = scraper.search("nonexistent_job_xyz")
+
+        assert result == []
+
+    @patch("nerajob.scrapers.adzuna.urlopen")
+    def test_api_error_graceful(self, mock_urlopen, clear_env):
+        os.environ["ADZUNA_APP_ID"] = "test_id"
+        os.environ["ADZUNA_APP_KEY"] = "test_key"
+
+        mock_urlopen.side_effect = OSError("Connection refused")
+
+        scraper = AdzunaScraper(country="us")
+        result = scraper.search("python")
+
+        assert result == []
+
+    @patch("nerajob.scrapers.adzuna.urlopen")
+    def test_results_capped_to_limit(self, mock_urlopen, clear_env):
+        os.environ["ADZUNA_APP_ID"] = "test_id"
+        os.environ["ADZUNA_APP_KEY"] = "test_key"
+
+        jobs = [
+            {
+                "id": str(i),
+                "title": f"Job {i}",
+                "company": {"display_name": f"Company {i}"},
+                "location": {"display_name": "Remote"},
+                "description": "desc",
+                "redirect_url": "https://example.com",
+                "salary_min": 50000,
+                "salary_max": 70000,
+                "salary_currency": "USD",
+                "contract_type": "permanent",
+                "created": "2026-07-10T10:00:00Z",
+            }
+            for i in range(30)
+        ]
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"results": jobs}).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+        scraper = AdzunaScraper(country="us")
+        result = scraper.search("test", limit=10)
+
+        assert len(result) == 10
+
+    @patch("nerajob.scrapers.adzuna.urlopen")
+    def test_malformed_result_skipped(self, mock_urlopen, clear_env):
+        os.environ["ADZUNA_APP_ID"] = "test_id"
+        os.environ["ADZUNA_APP_KEY"] = "test_key"
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({
+            "results": [
+                {"id": "1", "title": "Good", "company": {"display_name": "OK"},
+                 "location": {"display_name": "Here"}, "description": "desc",
+                 "redirect_url": "https://x.com", "created": "2026-07-10T10:00:00Z"},
+                None,  # Malformed — should be skipped
+                {"id": "3", "title": "Also Good", "company": {"display_name": "OK2"},
+                 "location": {"display_name": "There"}, "description": "desc2",
+                 "redirect_url": "https://y.com", "created": "2026-07-10T10:00:00Z"},
+            ]
+        }).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+        scraper = AdzunaScraper(country="us")
+        result = scraper.search("test")
+
+        assert len(result) == 2
+        assert result[0].title == "Good"
+        assert result[1].title == "Also Good"
+
+    @patch("nerajob.scrapers.adzuna.urlopen")
+    def test_url_includes_country(self, mock_urlopen, clear_env):
+        os.environ["ADZUNA_APP_ID"] = "test_id"
+        os.environ["ADZUNA_APP_KEY"] = "test_key"
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"results": []}).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+        scraper = AdzunaScraper(country="au")
+        scraper.search("python", limit=5)
+
+        # Verify URL includes country code
+        call_url = mock_urlopen.call_args[0][0].full_url if hasattr(mock_urlopen.call_args[0][0], 'full_url') else str(mock_urlopen.call_args[0][0])
+        assert "/au/" in call_url or "au/" in str(mock_urlopen.call_args)
+
+
+class TestBuildUrl:
+    def test_build_url_structure(self):
+        scraper = AdzunaScraper(country="us")
+        scraper._app_id = "myapp"
+        scraper._app_key = "mykey"
+        url = scraper._build_url("python developer", "San Francisco", page=1)
+        assert "api.adzuna.com" in url
+        assert "/us/" in url
+        assert "app_id=myapp" in url
+        assert "app_key=mykey" in url
+        assert "python%20developer" in url.lower() or "python+developer" in url
+
+    def test_build_url_no_location(self):
+        scraper = AdzunaScraper(country="gb")
+        scraper._app_id = "app"
+        scraper._app_key = "key"
+        url = scraper._build_url("engineer", "", page=2)
+        assert "/gb/" in url
+        assert "page=2" in url or "/2?" in url


### PR DESCRIPTION
## Description

Adds **Adzuna Jobs API** scraper with multi-country support.

## Changes

### `src/nerajob/scrapers/adzuna.py` (new)
- Full Adzuna API integration supporting **43 countries**
- Env config: `ADZUNA_APP_ID` + `ADZUNA_APP_KEY`
- CLI: `--country` flag (default: `us` via `NERAJOB_ADZUNA_COUNTRY`)
- Pagination with auto-page-through and limit cap
- Graceful error handling (missing API keys → empty list + warning)
- Malformed result skipping
- Free API signup at https://developer.adzuna.com/

### `src/nerajob/scrapers/registry.py`
- Registered `AdzunaScraper` in `available_scrapers()`
- Configurable via `NERAJOB_ADZUNA_COUNTRY` env var

### `.env.example`
- Added Adzuna API credentials section

### `tests/test_adzuna.py` (new)
- **11 tests** covering:
  - Country mapping (US, GB, DE, AU, IN)
  - Unsupported country error
  - Missing credentials → empty results + warning log
  - Mock HTTP for US (2 jobs with salary/currency validation)
  - Mock HTTP for GB (£ salary, London location)
  - Mock HTTP for DE (€ salary, Berlin location)
  - Empty results handling
  - API error graceful fallback
  - Result limit capping
  - Malformed result skipping
  - URL construction validation

## Developer Setup

```bash
# Get free keys at https://developer.adzuna.com/
export ADZUNA_APP_ID=your_app_id
export ADZUNA_APP_KEY=your_app_key
export NERAJOB_ADZUNA_COUNTRY=us  # optional, default: us

nerajob scan --source adzuna
```

Fixes #7