### PR TITLE
Add configurable match scoring weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ nerajob-gui
 | `nerajob scan --source …` | Scan one scraper |
 | `nerajob scan --all` | All registered scrapers |
 | `nerajob jobs list` | List cached jobs |
+| `nerajob jobs match` | Rank cached jobs with configurable match weights |
 | `nerajob cv build --target "…"` | Build Markdown + text CV |
 | `nerajob apply prepare --job-id <id>` | Apply package for one job |
 | `nerajob gui` / `nerajob-gui` | **Qt desktop app** (needs `.[gui]`) |
@@ -226,7 +227,12 @@ nerajob scan --source remoteok -q python -n 20
 nerajob cv build --target "Backend Engineer"
 nerajob apply prepare --job-id <id>
 nerajob jobs list
+nerajob jobs match --skill-weight 70 --title-weight 20 --location-weight 12
 ```
+
+Match scoring defaults to a 70-point skills cap, 20-point title/headline cap, and
+12-point location/remote cap. Adjust those weights when a search should favor
+role wording or location fit over direct skill hits.
 
 ---
 

--- a/src/nerajob/cli.py
+++ b/src/nerajob/cli.py
@@ -9,6 +9,7 @@ from rich.table import Table
 from nerajob import __version__
 from nerajob.apply.assistant import prepare_application
 from nerajob.cv.builder import write_cv_files
+from nerajob.match import DEFAULT_MATCH_WEIGHTS, MatchWeights
 from nerajob.models import JobPosting
 from nerajob.scrapers.registry import available_scrapers, get_scraper
 from nerajob.storage import (
@@ -263,6 +264,24 @@ def jobs_export(
 def jobs_match(
     top: int = typer.Option(10, "--top", "-k", min=1, max=50),
     job_id: str | None = typer.Option(None, "--job-id", "-j"),
+    skill_weight: float = typer.Option(
+        DEFAULT_MATCH_WEIGHTS.skills,
+        "--skill-weight",
+        min=0.0,
+        help="Maximum score contribution from profile skill matches",
+    ),
+    title_weight: float = typer.Option(
+        DEFAULT_MATCH_WEIGHTS.title,
+        "--title-weight",
+        min=0.0,
+        help="Maximum score contribution from headline/title overlap",
+    ),
+    location_weight: float = typer.Option(
+        DEFAULT_MATCH_WEIGHTS.location,
+        "--location-weight",
+        min=0.0,
+        help="Maximum score contribution from location or remote fit",
+    ),
 ) -> None:
     """Rank saved jobs against your profile (keyword skill match)."""
     from nerajob.match import match_score, rank_jobs
@@ -276,14 +295,19 @@ def jobs_match(
     if not jobs:
         console.print("[yellow]No jobs. Run: nerajob scan -q python[/yellow]")
         raise typer.Exit()
+    weights = MatchWeights(
+        skills=skill_weight,
+        title=title_weight,
+        location=location_weight,
+    )
     if job_id:
         job = next((j for j in jobs if j.id == job_id), None)
         if not job:
             console.print(f"[red]Unknown job id:[/red] {job_id}")
             raise typer.Exit(1)
-        console.print_json(data=match_score(profile, job))
+        console.print_json(data=match_score(profile, job, weights=weights))
         return
-    ranked = rank_jobs(profile, jobs, top_k=top)
+    ranked = rank_jobs(profile, jobs, top_k=top, weights=weights)
     table = Table(title=f"Job matches (top {len(ranked)})")
     table.add_column("Score")
     table.add_column("Band")

--- a/src/nerajob/match.py
+++ b/src/nerajob/match.py
@@ -2,7 +2,33 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from nerajob.models import JobPosting, Profile
+
+
+@dataclass(frozen=True)
+class MatchWeights:
+    """Score contribution caps for skills, title, and location matching."""
+
+    skills: float = 70.0
+    title: float = 20.0
+    location: float = 12.0
+
+    def __post_init__(self) -> None:
+        for name, value in self.as_dict().items():
+            if value < 0:
+                raise ValueError(f"{name} weight must be non-negative")
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "skills": float(self.skills),
+            "title": float(self.title),
+            "location": float(self.location),
+        }
+
+
+DEFAULT_MATCH_WEIGHTS = MatchWeights()
 
 # Common skill aliases for resume ↔ job matching (offline-friendly).
 SKILL_ALIASES: dict[str, set[str]] = {
@@ -44,6 +70,14 @@ SKILL_ALIASES: dict[str, set[str]] = {
 }
 
 
+def _coerce_weights(weights: MatchWeights | dict[str, float] | None) -> MatchWeights:
+    if weights is None:
+        return DEFAULT_MATCH_WEIGHTS
+    if isinstance(weights, MatchWeights):
+        return weights
+    return MatchWeights(**weights)
+
+
 def expand_skills(skills: set[str] | list[str] | tuple[str, ...]) -> set[str]:
     out = {str(s).lower().strip() for s in skills if str(s).strip()}
     for s in list(out):
@@ -53,11 +87,16 @@ def expand_skills(skills: set[str] | list[str] | tuple[str, ...]) -> set[str]:
     return out
 
 
-def match_score(profile: Profile, job: JobPosting) -> dict:
+def match_score(
+    profile: Profile,
+    job: JobPosting,
+    weights: MatchWeights | dict[str, float] | None = None,
+) -> dict:
     """
     Lightweight keyword match: skills vs title/description/tags + location soft score.
     Returns 0–100 score with explainable hits.
     """
+    score_weights = _coerce_weights(weights)
     base_skills = [s.strip().lower() for s in (profile.skills or []) if s.strip()]
     hay = f"{job.title} {job.description} {' '.join(job.tags)} {job.company}".lower()
     hits: list[str] = []
@@ -65,7 +104,11 @@ def match_score(profile: Profile, job: JobPosting) -> dict:
         aliases = expand_skills({s})
         if any(a and a in hay for a in aliases):
             hits.append(s)
-    skill_score = (len(hits) / max(1, len(base_skills))) * 70.0 if base_skills else 35.0
+    skill_score = (
+        (len(hits) / max(1, len(base_skills))) * score_weights.skills
+        if base_skills
+        else score_weights.skills * 0.5
+    )
 
     # headline / target role token overlap with job title
     headline_tokens = {
@@ -73,7 +116,7 @@ def match_score(profile: Profile, job: JobPosting) -> dict:
     }
     title_tokens = {t for t in job.title.lower().replace("/", " ").split() if len(t) > 2}
     role_overlap = headline_tokens & title_tokens
-    role_score = min(20.0, len(role_overlap) * 7.0)
+    role_score = min(score_weights.title, len(role_overlap) * (score_weights.title * 0.35))
 
     loc_score = 0.0
     pl = (profile.location or "").lower()
@@ -81,10 +124,11 @@ def match_score(profile: Profile, job: JobPosting) -> dict:
     prefers_remote = any(
         tok in pl for tok in ("remote", "wfh", "anywhere", "worldwide")
     ) or getattr(profile, "remote_ok", False)
+    partial_location_weight = score_weights.location * (10.0 / 12.0)
     if job.remote or "remote" in jl:
-        loc_score = 12.0 if prefers_remote else 10.0
+        loc_score = score_weights.location if prefers_remote else partial_location_weight
     elif pl and any(part in jl for part in pl.split() if len(part) > 2):
-        loc_score = 10.0
+        loc_score = partial_location_weight
 
     total = min(100.0, skill_score + role_score + loc_score)
     return {
@@ -96,11 +140,17 @@ def match_score(profile: Profile, job: JobPosting) -> dict:
         "role_overlap": sorted(role_overlap),
         "remote": job.remote,
         "location_boost": loc_score,
+        "score_weights": score_weights.as_dict(),
         "band": "strong" if total >= 70 else "medium" if total >= 40 else "weak",
     }
 
 
-def rank_jobs(profile: Profile, jobs: list[JobPosting], top_k: int = 20) -> list[dict]:
-    ranked = [match_score(profile, j) for j in jobs]
+def rank_jobs(
+    profile: Profile,
+    jobs: list[JobPosting],
+    top_k: int = 20,
+    weights: MatchWeights | dict[str, float] | None = None,
+) -> list[dict]:
+    ranked = [match_score(profile, j, weights=weights) for j in jobs]
     ranked.sort(key=lambda r: r["score"], reverse=True)
     return ranked[: max(1, top_k)]

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,4 +1,4 @@
-from nerajob.match import match_score, rank_jobs
+from nerajob.match import MatchWeights, match_score, rank_jobs
 from nerajob.models import JobPosting, Profile
 from nerajob.storage import default_profile
 
@@ -28,3 +28,70 @@ def test_rank_jobs() -> None:
     ]
     ranked = rank_jobs(profile, jobs, top_k=2)
     assert ranked[0]["job_id"] == "a"
+
+
+def test_match_score_accepts_custom_weights() -> None:
+    profile = Profile(
+        headline="Product Manager",
+        skills=["python"],
+        location="Berlin",
+    )
+    job = JobPosting(
+        id="j2",
+        source="sample",
+        title="Product Manager",
+        company="Acme",
+        location="Berlin, Germany",
+        description="Own roadmap and customer discovery",
+        tags=["product"],
+        remote=False,
+    )
+
+    score = match_score(
+        profile,
+        job,
+        weights=MatchWeights(skills=0.0, title=80.0, location=20.0),
+    )
+
+    assert score["score_weights"] == {"skills": 0.0, "title": 80.0, "location": 20.0}
+    assert score["score"] > 60
+
+
+def test_rank_jobs_uses_custom_weights() -> None:
+    profile = Profile(
+        headline="Product Manager",
+        skills=["python"],
+        location="Berlin",
+    )
+    jobs = [
+        JobPosting(
+            id="skill",
+            source="sample",
+            title="Python Backend Engineer",
+            company="Acme",
+            description="Build Python APIs",
+            tags=["python"],
+            remote=True,
+        ),
+        JobPosting(
+            id="title-location",
+            source="sample",
+            title="Product Manager",
+            company="Beta",
+            location="Berlin",
+            description="Own roadmap",
+            tags=["product"],
+            remote=False,
+        ),
+    ]
+
+    assert rank_jobs(profile, jobs, top_k=2)[0]["job_id"] == "skill"
+
+    ranked = rank_jobs(
+        profile,
+        jobs,
+        top_k=2,
+        weights=MatchWeights(skills=0.0, title=80.0, location=20.0),
+    )
+
+    assert ranked[0]["job_id"] == "title-location"


### PR DESCRIPTION
## Summary
- Adds configurable match scoring weights for skills, title, and location.
- Preserves the current default scoring behavior with documented defaults.
- Covers custom scoring and weighted ranking order with focused tests.

## Linked issue / bounty
- Fixes #64

## Problem
`nerajob jobs match` used fixed scoring weights, so users could not tune how much title and location signals should affect offline job matching versus skills overlap.

## Fix
- Adds a `MatchWeights` model with defaults of `skills=70`, `title=20`, and `location=12`.
- Threads those weights through `match_score()` and `rank_jobs()`.
- Adds `--skill-weight`, `--title-weight`, and `--location-weight` CLI options with non-negative validation.
- Documents the default weights in the README.

## Verification
QA-approved evidence:
- `python3 -m pytest tests/test_match.py -q` -> 4 passed
- `.venv/bin/python -m pytest -q` -> 48 passed
- `.venv/bin/ruff check src tests` -> all checks passed
- CLI temp-data check: default weights ranked the skill match first
- CLI temp-data check: `--skill-weight 0 --title-weight 80 --location-weight 20` ranked the title/location match first
- CLI temp-data check: single-job JSON included the configured `score_weights`
- CLI negative input check: `--skill-weight -1` exited 2 with Typer range rejection
- `git diff --check origin/master...HEAD` -> passed before PR opening

## Risk and rollback
- Scope is limited to match scoring, the `jobs match` CLI, README documentation, and tests.
- Defaults preserve existing match behavior; rollback is a normal revert of this PR.
- Open PR #27 touches adjacent CLI/match-score concepts, so this may need a small conflict resolution if that PR lands first.

## Maintainer notes
- No network, persistence, credential, account, or payment behavior changes.