### PR TITLE
test: add offline match precision fixtures

### DIFF
--- a/data/samples/jobs_match_precision.json
+++ b/data/samples/jobs_match_precision.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "backend-platform",
+    "source": "fixture",
+    "title": "Python Platform Engineer",
+    "company": "Northstar",
+    "location": "Remote",
+    "description": "Build FastAPI services, PostgreSQL data stores, and Docker deployment tooling.",
+    "tags": ["python", "fastapi", "postgres", "docker"],
+    "remote": true
+  },
+  {
+    "id": "frontend-product",
+    "source": "fixture",
+    "title": "Frontend Product Engineer",
+    "company": "Canvas",
+    "location": "Remote",
+    "description": "Create accessible React and TypeScript product experiences with Figma.",
+    "tags": ["typescript", "react", "figma"],
+    "remote": true
+  },
+  {
+    "id": "cloud-reliability",
+    "source": "fixture",
+    "title": "Cloud Reliability Engineer",
+    "company": "Orbit",
+    "location": "Remote",
+    "description": "Operate Kubernetes workloads with Terraform, AWS, and observability practices.",
+    "tags": ["kubernetes", "terraform", "aws", "sre"],
+    "remote": true
+  }
+]

--- a/src/nerajob/evaluation.py
+++ b/src/nerajob/evaluation.py
@@ -1,0 +1,18 @@
+"""Offline evaluation helpers for deterministic job-match fixtures."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def precision_at_k(ranked_job_ids: Iterable[str], relevant_job_ids: Iterable[str], k: int) -> float:
+    """Return the fraction of the first *k* ranked jobs that are relevant."""
+    if k < 1:
+        raise ValueError("k must be at least 1")
+
+    ranked = list(ranked_job_ids)[:k]
+    if not ranked:
+        return 0.0
+
+    relevant = set(relevant_job_ids)
+    return sum(job_id in relevant for job_id in ranked) / len(ranked)

--- a/tests/fixtures/resume_match_cases.json
+++ b/tests/fixtures/resume_match_cases.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "backend",
+    "profile": {
+      "headline": "Python Backend Engineer",
+      "location": "Remote",
+      "skills": ["python", "fastapi", "postgres"]
+    },
+    "relevant_job_ids": ["backend-platform"]
+  },
+  {
+    "name": "frontend",
+    "profile": {
+      "headline": "Frontend Engineer",
+      "location": "Remote",
+      "skills": ["typescript", "react", "figma"]
+    },
+    "relevant_job_ids": ["frontend-product"]
+  },
+  {
+    "name": "cloud",
+    "profile": {
+      "headline": "Cloud Platform Engineer",
+      "location": "Remote",
+      "skills": ["kubernetes", "aws", "terraform"]
+    },
+    "relevant_job_ids": ["cloud-reliability"]
+  }
+]

--- a/tests/test_match_precision.py
+++ b/tests/test_match_precision.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+from nerajob.evaluation import precision_at_k
+from nerajob.match import rank_jobs
+from nerajob.models import JobPosting, Profile
+
+
+ROOT = Path(__file__).parent.parent
+
+
+def _load_json(path: Path) -> list[dict]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_offline_resume_fixtures_have_perfect_precision_at_one() -> None:
+    jobs = [JobPosting(**item) for item in _load_json(ROOT / "data" / "samples" / "jobs_match_precision.json")]
+    cases = _load_json(Path(__file__).parent / "fixtures" / "resume_match_cases.json")
+
+    for case in cases:
+        profile = Profile(**case["profile"])
+        ranked_ids = [item["job_id"] for item in rank_jobs(profile, jobs, top_k=3)]
+        assert precision_at_k(ranked_ids, case["relevant_job_ids"], 1) == 1.0, case["name"]
+
+
+def test_precision_at_k_handles_short_rankings_and_rejects_invalid_k() -> None:
+    assert precision_at_k(["match"], ["match"], 3) == 1.0
+    assert precision_at_k([], ["match"], 1) == 0.0
+
+    try:
+        precision_at_k(["match"], ["match"], 0)
+    except ValueError as error:
+        assert str(error) == "k must be at least 1"
+    else:
+        raise AssertionError("expected invalid k to raise ValueError")


### PR DESCRIPTION
## Summary
- add three offline resume/profile match cases and three deterministic job fixtures
- add reusable precision@k evaluation helper
- verify each case ranks its relevant job first without network access

Fixes #60

## Tests
- `python -m pytest tests\\test_match.py tests\\test_match_precision.py` (4 passed)