### PR TITLE
feat: add remote-only job fixture and location filter tests (Closes #65)

### DIFF
--- a/data/samples/jobs_remote_only.json
+++ b/data/samples/jobs_remote_only.json
@@ -1,0 +1,89 @@
+[
+  {
+    "id": "remote_001",
+    "source": "fixture",
+    "title": "Senior Python Developer",
+    "company": "RemoteFirst Inc",
+    "location": "Remote",
+    "url": "https://example.com/jobs/remote_001",
+    "description": "Build scalable backend services with Python and FastAPI. 100% remote team.",
+    "tags": [
+      "python",
+      "fastapi",
+      "postgresql"
+    ],
+    "salary": "$120k-$160k",
+    "remote": true,
+    "scraped_at": "2026-07-15T00:00:00Z"
+  },
+  {
+    "id": "remote_002",
+    "source": "fixture",
+    "title": "Frontend Engineer",
+    "company": "DistributedCo",
+    "location": "Worldwide",
+    "url": "https://example.com/jobs/remote_002",
+    "description": "Build React applications for a fully distributed team.",
+    "tags": [
+      "javascript",
+      "react",
+      "typescript"
+    ],
+    "salary": "$100k-$140k",
+    "remote": true,
+    "scraped_at": "2026-07-15T00:00:00Z"
+  },
+  {
+    "id": "remote_003",
+    "source": "fixture",
+    "title": "DevOps Engineer",
+    "company": "CloudNative Labs",
+    "location": "Remote (US)",
+    "url": "https://example.com/jobs/remote_003",
+    "description": "Manage cloud infrastructure for remote-first startup.",
+    "tags": [
+      "devops",
+      "docker",
+      "kubernetes",
+      "aws"
+    ],
+    "salary": "$130k-$170k",
+    "remote": true,
+    "scraped_at": "2026-07-15T00:00:00Z"
+  },
+  {
+    "id": "remote_004",
+    "source": "fixture",
+    "title": "Technical Writer",
+    "company": "DocsGlobal",
+    "location": "Remote",
+    "url": "https://example.com/jobs/remote_004",
+    "description": "Write API documentation and developer guides for a remote team.",
+    "tags": [
+      "writing",
+      "documentation",
+      "markdown"
+    ],
+    "salary": "$80k-$110k",
+    "remote": true,
+    "scraped_at": "2026-07-15T00:00:00Z"
+  },
+  {
+    "id": "remote_005",
+    "source": "fixture",
+    "title": "QA Engineer",
+    "company": "TestAnywhere",
+    "location": "Remote (EU)",
+    "url": "https://example.com/jobs/remote_005",
+    "description": "Automated testing for remote SaaS platform.",
+    "tags": [
+      "qa",
+      "selenium",
+      "playwright",
+      "python"
+    ],
+    "salary": "$90k-$120k",
+    "remote": true,
+    "scraped_at": "2026-07-15T00:00:00Z"
+  }
+]

--- a/tests/test_location_filter.py
+++ b/tests/test_location_filter.py
@@ -1,0 +1,83 @@
+"""Tests for location filter using remote-only job fixture."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nerajob.models import JobPosting
+
+
+FIXTURE_PATH = Path(__file__).resolve().parent.parent / "data" / "samples" / "jobs_remote_only.json"
+
+
+def load_fixture() -> list[JobPosting]:
+    """Load the remote-only job fixture and validate."""
+    raw = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    return [JobPosting.model_validate(item) for item in raw]
+
+
+def test_fixture_file_exists() -> None:
+    """Fixture JSON file must exist."""
+    assert FIXTURE_PATH.exists(), f"Missing fixture: {FIXTURE_PATH}"
+
+
+def test_fixture_parses_to_job_postings() -> None:
+    """All entries must parse into valid JobPosting objects."""
+    jobs = load_fixture()
+    assert len(jobs) == 5
+    for job in jobs:
+        assert isinstance(job, JobPosting)
+        assert job.source == "fixture"
+
+
+def test_all_jobs_are_remote() -> None:
+    """Every job in the remote-only fixture must have remote=True."""
+    jobs = load_fixture()
+    for job in jobs:
+        assert job.remote is True, f"Job {job.id} is not remote: {job.remote}"
+
+
+def test_location_filter_keeps_only_remote() -> None:
+    """Location filter should keep all jobs when filtering for remote=True."""
+    jobs = load_fixture()
+    # Simulate a location filter: keep jobs where remote==True
+    remote_only = [j for j in jobs if j.remote]
+    assert len(remote_only) == len(jobs)
+    assert len(remote_only) == 5
+
+
+def test_location_filter_drops_non_remote() -> None:
+    """When mixing remote and on-site, location filter drops non-remote jobs."""
+    jobs = load_fixture()
+    # Add one on-site job to the mix
+    onsite = JobPosting(
+        id="onsite_001",
+        source="fixture",
+        title="Office Manager",
+        company="LocalCorp",
+        location="New York, NY",
+        url="https://example.com/jobs/onsite_001",
+        description="On-site office management.",
+        tags=["admin"],
+        salary="$50k-$70k",
+        remote=False,
+    )
+    all_jobs = jobs + [onsite]
+    # Filter for remote only
+    remote_only = [j for j in all_jobs if j.remote]
+    assert len(remote_only) == 5
+    assert onsite not in remote_only
+    # Verify remote jobs have recognizable remote locations
+    remote_locations = {j.location.lower() for j in remote_only}
+    assert any("remote" in loc for loc in remote_locations)
+
+
+def test_remote_jobs_have_expected_fields() -> None:
+    """Each remote job in the fixture must have required fields populated."""
+    jobs = load_fixture()
+    for job in jobs:
+        assert job.id, f"Job missing id"
+        assert job.title, f"Job {job.id} missing title"
+        assert job.company, f"Job {job.id} missing company"
+        assert job.tags, f"Job {job.id} missing tags"
+        assert job.remote is True, f"Job {job.id} remote is not True"


### PR DESCRIPTION
## Summary

Adds a remote-only job fixture (`data/samples/jobs_remote_only.json`) and location filter test suite (`tests/test_location_filter.py`).

## What's included

### Fixture: `data/samples/jobs_remote_only.json`
- 5 job entries, all tagged `remote: true`
- Diverse remote locations: "Remote", "Worldwide", "Remote (US)", "Remote (EU)"
- Follows the `JobPosting` model format from `nerajob.models`

### Tests: `tests/test_location_filter.py`
- `test_fixture_file_exists` — fixture must exist
- `test_fixture_parses_to_job_postings` — all entries validate as `JobPosting`
- `test_all_jobs_are_remote` — every job has `remote=True`
- `test_location_filter_keeps_only_remote` — filtering keeps all remote jobs
- `test_location_filter_drops_non_remote` — mixing in on-site, filter correctly drops it
- `test_remote_jobs_have_expected_fields` — required fields are populated

Closes #65