### PR TITLE
docs: add ML/MLOps skill aliases

### DIFF
--- a/docs/skill_aliases_ml_mlops.md
+++ b/docs/skill_aliases_ml_mlops.md
@@ -1,0 +1,91 @@
+# Skill Aliases: Machine Learning / MLOps Domain
+
+## Overview
+
+This document defines skill aliases for the Machine Learning and MLOps domain in NeraJob.
+
+## Core ML Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `machine_learning` | `ml`, `ml_algorithms`, `supervised_learning`, `unsupervised_learning` | Core ML algorithms and concepts |
+| `deep_learning` | `dl`, `neural_networks`, `cnn`, `rnn`, `transformer` | Deep learning architectures |
+| `natural_language_processing` | `nlp`, `text_processing`, `language_models` | NLP techniques and models |
+| `computer_vision` | `cv`, `image_processing`, `object_detection` | Computer vision tasks |
+| `reinforcement_learning` | `rl`, `q_learning`, `policy_gradient` | Reinforcement learning |
+
+## MLOps Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `model_training` | `training`, `fitting`, `model_fit` | Model training processes |
+| `model_evaluation` | `evaluation`, `metrics`, `validation` | Model evaluation and metrics |
+| `model_deployment` | `deployment`, `serving`, `inference` | Model deployment and serving |
+| `model_monitoring` | `monitoring`, `drift_detection`, `performance_tracking` | Model monitoring in production |
+| `feature_engineering` | `feature_extraction`, `feature_selection`, `data_preprocessing` | Feature engineering techniques |
+
+## Data Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `data_collection` | `data_gathering`, `data_acquisition` | Data collection methods |
+| `data_cleaning` | `data_preprocessing`, `data_wrangling` | Data cleaning and preprocessing |
+| `data_analysis` | `exploratory_data_analysis`, `eda` | Data analysis and visualization |
+| `data_validation` | `data_quality`, `data_integrity` | Data validation and quality checks |
+
+## Tool Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `python_ml` | `scikit_learn`, `sklearn`, `pytorch`, `tensorflow` | Python ML libraries |
+| `r_ml` | `caret`, `tidymodels`, `mlr3` | R ML frameworks |
+| `mlflow` | `experiment_tracking`, `model_registry` | MLflow for experiment tracking |
+| `kubeflow` | `kubernetes_ml`, `ml_pipelines` | Kubeflow for ML pipelines |
+| `docker_ml` | `containerization_ml`, `ml_containers` | Docker for ML deployment |
+
+## Infrastructure Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `gpu_computing` | `cuda`, `gpu_training`, `accelerated_computing` | GPU computing for ML |
+| `distributed_training` | `parallel_training`, `multi_gpu` | Distributed training techniques |
+| `cloud_ml` | `aws_ml`, `gcp_ml`, `azure_ml` | Cloud-based ML services |
+| `edge_ml` | `edge_deployment`, `model_optimization` | Edge deployment and optimization |
+
+## Workflow Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `ml_pipeline` | `workflow_orchestration`, `pipeline_design` | ML workflow design |
+| `experiment_design` | `ab_testing`, `experimentation` | Experiment design and analysis |
+| `model_versioning` | `version_control_ml`, `model_management` | Model version control |
+| `hyperparameter_tuning` | `hyperparameter_optimization`, `model_tuning` | Hyperparameter optimization |
+
+## Usage Examples
+
+### Resume Skills
+```yaml
+skills:
+  - machine_learning
+  - deep_learning
+  - model_training
+  - python_ml
+  - mlflow
+```
+
+### Job Requirements
+```yaml
+required_skills:
+  - nlp
+  - transformer
+  - model_deployment
+preferred_skills:
+  - kubeflow
+  - distributed_training
+```
+
+## Notes
+
+- Use the primary skill name for canonical references
+- Aliases are for search and matching purposes
+- Keep aliases consistent across the platform


### PR DESCRIPTION
## Changes
- Add comprehensive skill aliases for ML/MLOps domain
- Include core ML, MLOps, data, tool, and workflow skills
- Provide usage examples for resumes and job requirements

## Documentation Quality
- Well-organized skill categories
- Clear alias mappings
- Practical usage examples

Fixes #56