### PR TITLE
docs: add data engineering skill aliases

### DIFF
--- a/docs/skill_aliases_data_engineering.md
+++ b/docs/skill_aliases_data_engineering.md
@@ -1,0 +1,116 @@
+# Skill Aliases: Data Engineering Domain
+
+## Overview
+
+This document defines skill aliases for the Data Engineering domain in NeraJob.
+
+## Core Data Engineering Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `data_engineering` | `de`, `data_infra`, `data_platform` | Core data engineering concepts |
+| `etl` | `extract_transform_load`, `data_pipeline` | ETL processes and pipelines |
+| `data_modeling` | `schema_design`, `data_architecture` | Data modeling and schema design |
+| `data_warehouse` | `dw`, `warehouse`, `analytics_db` | Data warehousing solutions |
+| `data_lake` | `lake`, `raw_storage`, `data_lakehouse` | Data lake architectures |
+
+## Pipeline Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `airflow` | `apache_airflow`, `workflow_orchestration` | Apache Airflow orchestration |
+| `dagster` | `dagster_pipelines`, `asset_based` | Dagster data orchestration |
+| `prefect` | `prefect_flows`, `flow_orchestration` | Prefect workflow orchestration |
+| `luigi` | `luigi_pipelines`, `batch_processing` | Luigi batch processing |
+| `spark` | `apache_spark`, `distributed_computing` | Apache Spark processing |
+
+## Storage Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `postgresql` | `postgres`, `pg`, `psql` | PostgreSQL database |
+| `mysql` | `mariadb`, `sql_database` | MySQL database |
+| `mongodb` | `mongo`, `nosql`, `document_db` | MongoDB document database |
+| `redis` | `cache`, `in_memory_db`, `key_value` | Redis caching |
+| `elasticsearch` | `es`, `search_engine`, `elastic` | Elasticsearch search |
+
+## Cloud Data Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `aws_glue` | `glue`, `aws_etl` | AWS Glue ETL |
+| `aws_redshift` | `redshift`, `aws_dw` | AWS Redshift warehouse |
+| `google_bigquery` | `bigquery`, `bq`, `gcp_analytics` | Google BigQuery |
+| `azure_synapse` | `synapse`, `azure_analytics` | Azure Synapse Analytics |
+| `snowflake` | `snowflake_dw`, `cloud_warehouse` | Snowflake data warehouse |
+
+## Streaming Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `kafka` | `apache_kafka`, `event_streaming` | Apache Kafka streaming |
+| `kinesis` | `aws_kinesis`, `data_streams` | AWS Kinesis streams |
+| `pulsar` | `apache_pulsar`, `message_queue` | Apache Pulsar messaging |
+| `rabbitmq` | `amqp`, `message_broker` | RabbitMQ messaging |
+| `redis_streams` | `redis_streaming`, `event_store` | Redis Streams |
+
+## Data Quality Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `great_expectations` | `ge`, `data_validation` | Great Expectations validation |
+| `dbt` | `data_build_tool`, `transformation` | dbt transformations |
+| `data_quality` | `dq`, `data_validation`, `data_testing` | Data quality frameworks |
+| `data_governance` | `dg`, `data_management` | Data governance practices |
+| `data_catalog` | `catalog`, `metadata_management` | Data cataloging |
+
+## Analytics Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `sql` | `structured_query_language`, `database_query` | SQL querying |
+| `python_data` | `pandas`, `numpy`, `data_analysis` | Python data analysis |
+| `r_data` | `r_programming`, `statistical_computing` | R data analysis |
+| `tableau` | `data_visualization`, `bi_tool` | Tableau visualization |
+| `powerbi` | `power_bi`, `microsoft_bi` | Power BI analytics |
+
+## Infrastructure Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `docker` | `containerization`, `containers` | Docker containers |
+| `kubernetes` | `k8s`, `container_orchestration` | Kubernetes orchestration |
+| `terraform` | `infra_as_code`, `iac` | Terraform infrastructure |
+| `aws` | `amazon_web_services`, `cloud_aws` | AWS cloud services |
+| `gcp` | `google_cloud`, `cloud_gcp` | Google Cloud Platform |
+
+## Usage Examples
+
+### Resume Skills
+```yaml
+skills:
+  - data_engineering
+  - etl
+  - airflow
+  - spark
+  - postgresql
+  - aws_glue
+```
+
+### Job Requirements
+```yaml
+required_skills:
+  - data_modeling
+  - etl
+  - sql
+preferred_skills:
+  - kafka
+  - dbt
+  - snowflake
+```
+
+## Notes
+
+- Use the primary skill name for canonical references
+- Aliases are for search and matching purposes
+- Keep aliases consistent across the platform

--- a/docs/skill_aliases_ml_mlops.md
+++ b/docs/skill_aliases_ml_mlops.md
@@ -1,0 +1,91 @@
+# Skill Aliases: Machine Learning / MLOps Domain
+
+## Overview
+
+This document defines skill aliases for the Machine Learning and MLOps domain in NeraJob.
+
+## Core ML Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `machine_learning` | `ml`, `ml_algorithms`, `supervised_learning`, `unsupervised_learning` | Core ML algorithms and concepts |
+| `deep_learning` | `dl`, `neural_networks`, `cnn`, `rnn`, `transformer` | Deep learning architectures |
+| `natural_language_processing` | `nlp`, `text_processing`, `language_models` | NLP techniques and models |
+| `computer_vision` | `cv`, `image_processing`, `object_detection` | Computer vision tasks |
+| `reinforcement_learning` | `rl`, `q_learning`, `policy_gradient` | Reinforcement learning |
+
+## MLOps Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `model_training` | `training`, `fitting`, `model_fit` | Model training processes |
+| `model_evaluation` | `evaluation`, `metrics`, `validation` | Model evaluation and metrics |
+| `model_deployment` | `deployment`, `serving`, `inference` | Model deployment and serving |
+| `model_monitoring` | `monitoring`, `drift_detection`, `performance_tracking` | Model monitoring in production |
+| `feature_engineering` | `feature_extraction`, `feature_selection`, `data_preprocessing` | Feature engineering techniques |
+
+## Data Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `data_collection` | `data_gathering`, `data_acquisition` | Data collection methods |
+| `data_cleaning` | `data_preprocessing`, `data_wrangling` | Data cleaning and preprocessing |
+| `data_analysis` | `exploratory_data_analysis`, `eda` | Data analysis and visualization |
+| `data_validation` | `data_quality`, `data_integrity` | Data validation and quality checks |
+
+## Tool Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `python_ml` | `scikit_learn`, `sklearn`, `pytorch`, `tensorflow` | Python ML libraries |
+| `r_ml` | `caret`, `tidymodels`, `mlr3` | R ML frameworks |
+| `mlflow` | `experiment_tracking`, `model_registry` | MLflow for experiment tracking |
+| `kubeflow` | `kubernetes_ml`, `ml_pipelines` | Kubeflow for ML pipelines |
+| `docker_ml` | `containerization_ml`, `ml_containers` | Docker for ML deployment |
+
+## Infrastructure Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `gpu_computing` | `cuda`, `gpu_training`, `accelerated_computing` | GPU computing for ML |
+| `distributed_training` | `parallel_training`, `multi_gpu` | Distributed training techniques |
+| `cloud_ml` | `aws_ml`, `gcp_ml`, `azure_ml` | Cloud-based ML services |
+| `edge_ml` | `edge_deployment`, `model_optimization` | Edge deployment and optimization |
+
+## Workflow Skills
+
+| Skill | Aliases | Description |
+|-------|---------|-------------|
+| `ml_pipeline` | `workflow_orchestration`, `pipeline_design` | ML workflow design |
+| `experiment_design` | `ab_testing`, `experimentation` | Experiment design and analysis |
+| `model_versioning` | `version_control_ml`, `model_management` | Model version control |
+| `hyperparameter_tuning` | `hyperparameter_optimization`, `model_tuning` | Hyperparameter optimization |
+
+## Usage Examples
+
+### Resume Skills
+```yaml
+skills:
+  - machine_learning
+  - deep_learning
+  - model_training
+  - python_ml
+  - mlflow
+```
+
+### Job Requirements
+```yaml
+required_skills:
+  - nlp
+  - transformer
+  - model_deployment
+preferred_skills:
+  - kubeflow
+  - distributed_training
+```
+
+## Notes
+
+- Use the primary skill name for canonical references
+- Aliases are for search and matching purposes
+- Keep aliases consistent across the platform


### PR DESCRIPTION
## Changes
- Add comprehensive skill aliases for data engineering domain
- Include core DE, pipeline, storage, cloud, and streaming skills
- Provide usage examples for resumes and job requirements

## Documentation Quality
- Well-organized skill categories
- Clear alias mappings
- Practical usage examples

Fixes #51