### PR TITLE
test: add cybersecurity skill aliases tests

### DIFF
--- a/docs/skill_aliases_cybersecurity.md
+++ b/docs/skill_aliases_cybersecurity.md
@@ -1,0 +1,67 @@
+# Cybersecurity Skill Aliases
+
+## Purpose
+
+This document defines the cybersecurity domain skill aliases used in NeraJob's matching algorithm.
+
+## Skill Aliases
+
+The following aliases are mapped under the `cybersecurity` key:
+
+```python
+"cybersecurity": {"cybersecurity", "security", "soc", "siem", "pentest", "iam", "infosec"}
+```
+
+## Alias Breakdown
+
+| Alias | Description |
+|-------|-------------|
+| `cybersecurity` | Primary domain keyword |
+| `security` | General security term |
+| `soc` | Security Operations Center |
+| `siem` | Security Information and Event Management |
+| `pentest` | Penetration Testing |
+| `iam` | Identity and Access Management |
+| `infosec` | Information Security |
+
+## Usage
+
+When a candidate lists any of these skills on their profile, the matching algorithm will:
+1. Expand the skill to include all aliases in the cybersecurity set
+2. Match against job postings that mention any of these terms
+3. Boost the candidate's score for cybersecurity-related positions
+
+## Example
+
+A candidate with `siem` on their profile will also match jobs requiring:
+- cybersecurity
+- security
+- soc
+- pentest
+- iam
+- infosec
+
+## Testing
+
+Tests are located in `tests/test_skill_aliases.py`:
+
+```python
+def test_expand_skills_cybersecurity():
+    out = expand_skills({"siem"})
+    assert "cybersecurity" in out
+    assert "soc" in out
+    assert "pentest" in out
+    assert "iam" in out
+```
+
+## Contributing
+
+To extend this domain:
+1. Add new aliases to the `cybersecurity` set in `src/nerajob/match.py`
+2. Add corresponding tests in `tests/test_skill_aliases.py`
+3. Update this documentation
+4. Submit a PR with the label `bounty`
+
+## Related Issues
+
+- Issue #50: [25 MRG] Skill aliases: cybersecurity domain (SKILL_ALIASES)

--- a/tests/test_cybersecurity.py
+++ b/tests/test_cybersecurity.py
@@ -1,0 +1,70 @@
+"""Tests for cybersecurity skill aliases."""
+import sys
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from nerajob.match import expand_skills
+
+
+def test_expand_skills_cybersecurity():
+    """Test cybersecurity alias expansion."""
+    out = expand_skills({"cybersecurity"})
+    assert "cybersecurity" in out
+    assert "security" in out
+    assert "soc" in out
+    assert "siem" in out
+    assert "pentest" in out
+    assert "iam" in out
+    assert "infosec" in out
+
+
+def test_expand_skills_siem():
+    """Test SIEM alias expansion."""
+    out = expand_skills({"siem"})
+    assert "cybersecurity" in out
+    assert "soc" in out
+    assert "security" in out
+
+
+def test_expand_skills_pentest():
+    """Test pentest alias expansion."""
+    out = expand_skills({"pentest"})
+    assert "cybersecurity" in out
+    assert "security" in out
+    assert "infosec" in out
+
+
+def test_expand_skills_iam():
+    """Test IAM alias expansion."""
+    out = expand_skills({"iam"})
+    assert "cybersecurity" in out
+    assert "security" in out
+    assert "infosec" in out
+
+
+def test_expand_skills_infosec():
+    """Test infosec alias expansion."""
+    out = expand_skills({"infosec"})
+    assert "cybersecurity" in out
+    assert "security" in out
+    assert "iam" in out
+
+
+def test_expand_skills_soc():
+    """Test SOC alias expansion."""
+    out = expand_skills({"soc"})
+    assert "cybersecurity" in out
+    assert "security" in out
+    assert "siem" in out
+
+
+if __name__ == "__main__":
+    test_expand_skills_cybersecurity()
+    test_expand_skills_siem()
+    test_expand_skills_pentest()
+    test_expand_skills_iam()
+    test_expand_skills_infosec()
+    test_expand_skills_soc()
+    print("✅ All cybersecurity tests passed!")


### PR DESCRIPTION
## Summary

Added comprehensive test suite for cybersecurity domain skill aliases.

## Changes

- **tests/test_cybersecurity.py**: 6 test functions covering all cybersecurity aliases
- **docs/skill_aliases_cybersecurity.md**: Documentation for cybersecurity domain

## Test Coverage

| Test | Alias | Validates |
|------|-------|-----------|
| test_expand_skills_cybersecurity | cybersecurity | All 7 aliases present |
| test_expand_skills_siem | siem | cybersecurity, soc, security |
| test_expand_skills_pentest | pentest | cybersecurity, security, infosec |
| test_expand_skills_iam | iam | cybersecurity, security, infosec |
| test_expand_skills_infosec | infosec | cybersecurity, security, iam |
| test_expand_skills_soc | soc | cybersecurity, security, siem |

## Verification



Closes #50