### PR TITLE
feat: add nerajob skills extract --text-file for offline skill extraction

### DIFF
--- a/data/samples/resume_skills_extract.txt
+++ b/data/samples/resume_skills_extract.txt
@@ -1,0 +1,23 @@
+Senior Full-Stack Developer
+Remote · san@example.com
+
+Skills
+Python, Django, FastAPI, JavaScript, React, TypeScript, PostgreSQL,
+Docker, Kubernetes, AWS, Terraform, CI/CD, Git
+
+Experience
+Senior Backend Engineer — TechCorp (2021–Present)
+- Built REST APIs with Django and FastAPI serving 10M+ requests/day
+- Migrated monolith to microservices on Kubernetes
+- Implemented CI/CD pipelines with GitHub Actions
+
+Full-Stack Developer — StartupX (2019–2021)
+- Developed React frontend with TypeScript
+- Managed PostgreSQL databases and wrote complex queries
+- Deployed infrastructure on AWS using Terraform
+
+Education
+B.S. Computer Science — University of Technology
+
+Languages
+English (Native), Vietnamese (Native)

--- a/src/nerajob/cli.py
+++ b/src/nerajob/cli.py
@@ -7,6 +7,7 @@ from rich.console import Console
 from rich.table import Table
 
 from nerajob import __version__
+from nerajob.match import SKILL_ALIASES, expand_skills, extract_skills_from_text
 from nerajob.apply.assistant import prepare_application
 from nerajob.cv.builder import write_cv_files
 from nerajob.match import DEFAULT_MATCH_WEIGHTS, MatchWeights
@@ -40,9 +41,31 @@ def version_cmd() -> None:
 
 
 @app.command("skills")
-def skills_cmd() -> None:
-    """List skill alias groups used by match scoring."""
-    from nerajob.match import SKILL_ALIASES
+def skills_cmd(
+    text_file: Path | None = typer.Option(
+        None,
+        "--text-file",
+        "-f",
+        exists=True,
+        readable=True,
+        help="Extract skills from a plain-text resume file",
+    ),
+) -> None:
+    """List skill alias groups or extract skills from a text file."""
+    if text_file:
+        text = text_file.read_text(encoding="utf-8")
+        matched = extract_skills_from_text(text)
+        if not matched:
+            console.print("[yellow]No recognized skills found in text.[/yellow]")
+            raise typer.Exit()
+        total = sum(len(skills) for skills in matched.values())
+        table = Table(title=f"Skills extracted ({total} matches in {len(matched)} domains)")
+        table.add_column("Domain")
+        table.add_column("Matched skills")
+        for domain in sorted(matched):
+            table.add_row(domain, ", ".join(sorted(matched[domain])))
+        console.print(table)
+        return
 
     table = Table(title=f"Skill aliases ({len(SKILL_ALIASES)})")
     table.add_column("Group")

--- a/src/nerajob/match.py
+++ b/src/nerajob/match.py
@@ -86,6 +86,26 @@ SKILL_ALIASES: dict[str, set[str]] = {
 }
 
 
+def extract_skills_from_text(text: str) -> dict[str, set[str]]:
+    """
+    Parse free-form text and extract known skill tokens matched against SKILL_ALIASES.
+
+    Returns a mapping of domain → matched skill tokens found in the text.
+    """
+    import re
+
+    normalized = text.lower()
+    result: dict[str, set[str]] = {}
+    for domain, aliases in SKILL_ALIASES.items():
+        matched: set[str] = set()
+        for alias in aliases:
+            if alias in normalized:
+                matched.add(alias)
+        if matched:
+            result[domain] = matched
+    return result
+
+
 def _coerce_weights(weights: MatchWeights | dict[str, float] | None) -> MatchWeights:
     if weights is None:
         return DEFAULT_MATCH_WEIGHTS

--- a/tests/test_skill_extract.py
+++ b/tests/test_skill_extract.py
@@ -1,0 +1,65 @@
+"""Tests for offline skill extraction from plain text."""
+
+from pathlib import Path
+
+from nerajob.match import extract_skills_from_text
+
+
+def test_extract_skills_from_python_text():
+    text = "Expert in Python, Django, and FastAPI. Experience with PostgreSQL."
+    result = extract_skills_from_text(text)
+    assert "python" in result
+    assert "django" in result["python"]
+    assert "fastapi" in result["python"]
+    assert "sql" in result
+    assert "postgres" in result["sql"] or "postgresql" in result["sql"]
+
+
+def test_extract_skills_from_devops_text():
+    text = "DevOps engineer with Docker, Kubernetes, Terraform, and CI/CD."
+    result = extract_skills_from_text(text)
+    assert "devops" in result
+    assert "docker" in result["devops"]
+    assert "kubernetes" in result["devops"]
+    assert "terraform" in result["devops"]
+
+
+def test_extract_skills_from_full_resume():
+    text = """Senior Python Backend Engineer
+
+Experience with FastAPI, Django, and PostgreSQL.
+Cloud infrastructure on AWS with Lambda and S3.
+Containerized with Docker and Kubernetes."""
+    result = extract_skills_from_text(text)
+    assert "python" in result
+    assert "sql" in result
+    assert "cloud" in result
+    assert "devops" in result
+
+
+def test_extract_skills_no_match():
+    text = "I enjoy long walks on the beach and reading books."
+    result = extract_skills_from_text(text)
+    assert result == {}
+
+
+def test_extract_skills_multiword_alias():
+    text = "Experienced with infrastructure as code and continuous integration."
+    result = extract_skills_from_text(text)
+    devops = result.get("devops", set())
+    assert "infrastructure as code" in devops or "iac" in devops
+
+
+def test_extract_skills_case_insensitive():
+    text = "PYTHON DJANGO KUBERNETES"
+    result = extract_skills_from_text(text)
+    assert "python" in result
+    assert "devops" in result
+
+
+def test_extract_skills_with_textfile(tmp_path: Path) -> None:
+    txt = tmp_path / "resume.txt"
+    txt.write_text("Python developer with Flask and MongoDB experience.", encoding="utf-8")
+    result = extract_skills_from_text(txt.read_text(encoding="utf-8"))
+    assert "python" in result
+    assert "flask" in result["python"]


### PR DESCRIPTION
## Summary

Adds offline skill extraction from plain-text resumes.

### Changes
- `match.py`: new `extract_skills_from_text(text)` function — parses free text against SKILL_ALIASES
- `cli.py`: `nerajob skills --text-file <path>` command — reads a file, extracts matched skills grouped by domain
- `tests/test_skill_extract.py`: 7 unit tests covering Python, DevOps, full resume, no-match, multi-word aliases, case insensitivity, and file-based input
- `data/samples/resume_skills_extract.txt`: sample resume fixture for testing

### Usage
```
nerajob skills --text-file data/samples/resume_skills_extract.txt
```

### Acceptance
- [x] CLI + tests + sample text fixture

Closes #61