### PR TITLE
feat: scan preset profile + dedupe count report [bounties #41 #19]

### DIFF
--- a/data/cv/cv-software-engineer.md
+++ b/data/cv/cv-software-engineer.md
@@ -1,0 +1,23 @@
+# Your Name
+**Software Engineer**  
+Remote · you@example.com
+
+https://github.com/your-handle · https://linkedin.com/in/your-handle
+
+## Summary
+Results-driven engineer building reliable products.
+
+## Skills
+Python, APIs, SQL
+
+## Experience
+### Software Engineer — Example Co
+*2022 – Present*
+- Built APIs and automation used by product teams
+- Improved reliability and delivery speed
+
+## Education
+- B.S. Computer Science · University · 2021
+
+## Languages
+English

--- a/data/cv/cv-software-engineer.txt
+++ b/data/cv/cv-software-engineer.txt
@@ -1,0 +1,23 @@
+Your Name
+Software Engineer  
+Remote · you@example.com
+
+https://github.com/your-handle · https://linkedin.com/in/your-handle
+
+#Summary
+Results-driven engineer building reliable products.
+
+#Skills
+Python, APIs, SQL
+
+#Experience
+##Software Engineer — Example Co
+2022 – Present
+- Built APIs and automation used by product teams
+- Improved reliability and delivery speed
+
+#Education
+- B.S. Computer Science · University · 2021
+
+#Languages
+English

--- a/src/nerajob/cli.py
+++ b/src/nerajob/cli.py
@@ -13,7 +13,6 @@ from nerajob.cv.builder import write_cv_files
 from nerajob.match import DEFAULT_MATCH_WEIGHTS, MatchWeights
 from nerajob.models import JobPosting
 from nerajob.scrapers.registry import available_scrapers, get_scraper
-from nerajob.models import ScanPreset
 from nerajob.storage import (
     default_profile,
     get_job,

--- a/src/nerajob/cli.py
+++ b/src/nerajob/cli.py
@@ -7,18 +7,21 @@ from rich.console import Console
 from rich.table import Table
 
 from nerajob import __version__
-from nerajob.match import SKILL_ALIASES, expand_skills, extract_skills_from_text
+from nerajob.match import SKILL_ALIASES, extract_skills_from_text
 from nerajob.apply.assistant import prepare_application
 from nerajob.cv.builder import write_cv_files
 from nerajob.match import DEFAULT_MATCH_WEIGHTS, MatchWeights
 from nerajob.models import JobPosting
 from nerajob.scrapers.registry import available_scrapers, get_scraper
+from nerajob.models import ScanPreset
 from nerajob.storage import (
     default_profile,
     get_job,
     load_jobs,
     load_profile,
+    load_scan_preset,
     save_profile,
+    save_scan_preset,
     upsert_jobs,
 )
 
@@ -103,6 +106,30 @@ def profile_show() -> None:
     console.print_json(profile.model_dump_json(indent=2))
 
 
+@profile_app.command("preset")
+def profile_preset(
+    remote_only: bool | None = typer.Option(None, "--remote-only", help="Filter to remote jobs by default"),
+    skill_filters: str = typer.Option("", "--skills", help="Comma-separated skills to filter on"),
+    min_score: float = typer.Option(-1.0, "--min-score", help="Minimum match score (0–100)"),
+    min_salary: int = typer.Option(-1, "--min-salary", help="Minimum annual salary"),
+    max_results: int = typer.Option(-1, "--max-results", help="Max results per scan"),
+) -> None:
+    preset = load_scan_preset()
+    if remote_only is not None:
+        preset = preset.model_copy(update={"remote_only": remote_only})
+    if skill_filters:
+        preset = preset.model_copy(update={"skill_filters": [s.strip() for s in skill_filters.split(",") if s.strip()]})
+    if min_score >= 0:
+        preset = preset.model_copy(update={"min_score": min_score})
+    if min_salary >= 0:
+        preset = preset.model_copy(update={"min_salary": min_salary})
+    if max_results >= 0:
+        preset = preset.model_copy(update={"max_results": max_results})
+    save_scan_preset(preset)
+    console.print("[green]Scan preset saved:[/green]")
+    console.print_json(preset.model_dump_json(indent=2))
+
+
 @app.command("scan")
 def scan_cmd(
     query: str = typer.Option("", "--query", "-q", help="Keywords"),
@@ -115,19 +142,32 @@ def scan_cmd(
         help=f"Scraper name: {', '.join(sorted(available_scrapers()))}",
     ),
     all_sources: bool = typer.Option(False, "--all", help="Run all registered scrapers"),
-    remote_only: bool = typer.Option(False, "--remote-only", help="Keep only remote jobs"),
+    remote_only: bool | None = typer.Option(None, "--remote-only/--no-remote-only", help="Keep only remote jobs"),
+    skill_filters: str = typer.Option("", "--skills", help="Comma-separated skills to filter on"),
     min_score: float = typer.Option(
-        0.0,
+        -1.0,
         "--min-score",
         help="If profile exists, drop jobs below this match score (0–100)",
     ),
     min_salary: int = typer.Option(
-        0,
+        -1,
         "--min-salary",
         help="Filter jobs by minimum annual salary (e.g. 50000 for 50k)",
     ),
 ) -> None:
     """Scan job sources and save matches under data/jobs.json."""
+    preset = load_scan_preset()
+    if remote_only is None:
+        remote_only = preset.remote_only
+    if not skill_filters:
+        skill_filters = ",".join(preset.skill_filters)
+    if min_score < 0:
+        min_score = preset.min_score
+    if min_salary < 0:
+        min_salary = preset.min_salary
+    if limit == 20 and preset.max_results:
+        limit = preset.max_results
+
     names = list(available_scrapers()) if all_sources else [source]
     collected: list[JobPosting] = []
     for name in names:
@@ -145,8 +185,8 @@ def scan_cmd(
         console.print("[yellow]No hits from live source; falling back to sample feed.[/yellow]")
         collected = get_scraper("sample").search(query=query, location=location, limit=limit)
 
-    # Dedupe across sources (scan --all): prefer first occurrence, keep stable order
-    before = len(collected)
+    # Dedupe across sources: prefer first occurrence, keep stable order
+    fetched_count = len(collected)
     seen_keys: set[str] = set()
     deduped: list[JobPosting] = []
     for job in collected:
@@ -156,8 +196,8 @@ def scan_cmd(
         seen_keys.add(key)
         deduped.append(job)
     collected = deduped
-    if all_sources and before != len(collected):
-        console.print(f"[dim]Deduped[/dim] {before} → {len(collected)} unique jobs")
+    if fetched_count != len(collected):
+        console.print(f"[dim]Deduped[/dim] {fetched_count} fetched → {len(collected)} unique (dropped {fetched_count - len(collected)} duplicates)")
 
     if remote_only:
         collected = [
@@ -166,6 +206,18 @@ def scan_cmd(
             if j.remote or "remote" in (j.location or "").lower()
         ]
         console.print(f"[dim]remote-only[/dim] {len(collected)} jobs")
+
+    if skill_filters:
+        filter_skills = [s.strip().lower() for s in skill_filters.split(",") if s.strip()]
+        before_s = len(collected)
+        scored = []
+        for job in collected:
+            job_tags = [t.lower() for t in (job.tags or [])]
+            job_skills = (job.description or "").lower()
+            if any(s in job_tags or s in job_skills for s in filter_skills):
+                scored.append(job)
+        collected = scored
+        console.print(f"[dim]skill-filters ({','.join(filter_skills)})[/dim] {before_s} → {len(collected)} jobs")
 
     if min_score > 0:
         from nerajob.match import match_score

--- a/src/nerajob/config.py
+++ b/src/nerajob/config.py
@@ -34,3 +34,4 @@ def http_timeout() -> float:
 PROFILE_PATH = data_dir() / "profile.json"
 JOBS_PATH = data_dir() / "jobs.json"
 APPLICATIONS_DIR = data_dir() / "applications"
+SCAN_PRESET_PATH = data_dir() / "scan-preset.json"

--- a/src/nerajob/match.py
+++ b/src/nerajob/match.py
@@ -92,8 +92,6 @@ def extract_skills_from_text(text: str) -> dict[str, set[str]]:
 
     Returns a mapping of domain → matched skill tokens found in the text.
     """
-    import re
-
     normalized = text.lower()
     result: dict[str, set[str]] = {}
     for domain, aliases in SKILL_ALIASES.items():

--- a/src/nerajob/models.py
+++ b/src/nerajob/models.py
@@ -53,6 +53,14 @@ class JobPosting(BaseModel):
     raw: dict[str, Any] = Field(default_factory=dict)
 
 
+class ScanPreset(BaseModel):
+    remote_only: bool = False
+    skill_filters: list[str] = Field(default_factory=list)
+    min_score: float = 0.0
+    min_salary: int = 0
+    max_results: int = 20
+
+
 class ApplicationPackage(BaseModel):
     job_id: str
     created_at: str = Field(default_factory=utc_now_iso)

--- a/src/nerajob/storage.py
+++ b/src/nerajob/storage.py
@@ -4,8 +4,8 @@ import json
 from pathlib import Path
 from typing import Iterable
 
-from nerajob.config import APPLICATIONS_DIR, JOBS_PATH, PROFILE_PATH
-from nerajob.models import ApplicationPackage, Education, Experience, JobPosting, Profile
+from nerajob.config import APPLICATIONS_DIR, JOBS_PATH, PROFILE_PATH, SCAN_PRESET_PATH
+from nerajob.models import ApplicationPackage, Education, Experience, JobPosting, Profile, ScanPreset
 
 
 def _read_json(path: Path, default):
@@ -80,6 +80,15 @@ def get_job(job_id: str) -> JobPosting | None:
         if job.id == job_id:
             return job
     return None
+
+
+def load_scan_preset() -> ScanPreset:
+    return ScanPreset.model_validate(_read_json(SCAN_PRESET_PATH, {}))
+
+
+def save_scan_preset(preset: ScanPreset) -> Path:
+    _write_json(SCAN_PRESET_PATH, preset.model_dump())
+    return SCAN_PRESET_PATH
 
 
 def save_application(package: ApplicationPackage) -> Path:

--- a/tests/test_scan_preset.py
+++ b/tests/test_scan_preset.py
@@ -1,0 +1,31 @@
+"""Tests for scan preset profile."""
+
+from pathlib import Path
+
+from nerajob.models import ScanPreset
+from nerajob.storage import load_scan_preset, save_scan_preset
+
+
+def test_scan_preset_defaults():
+    preset = ScanPreset()
+    assert preset.remote_only is False
+    assert preset.skill_filters == []
+    assert preset.min_score == 0.0
+    assert preset.min_salary == 0
+    assert preset.max_results == 20
+
+
+def test_scan_perset_roundtrip(tmp_path: Path) -> None:
+    from nerajob import config as cfg
+
+    original = cfg.SCAN_PRESET_PATH
+    try:
+        cfg.SCAN_PRESET_PATH = tmp_path / "scan-preset.json"
+        preset = ScanPreset(remote_only=True, skill_filters=["python"], min_score=30.0)
+        save_scan_preset(preset)
+        loaded = load_scan_preset()
+        assert loaded.remote_only is True
+        assert loaded.skill_filters == ["python"]
+        assert loaded.min_score == 30.0
+    finally:
+        cfg.SCAN_PRESET_PATH = original


### PR DESCRIPTION
## Summary

Two bounties in one PR:

### [#41] Feature: remote-only default profile preset [50 MRG]
- New `nerajob profile preset` command to save scan defaults
- Supports: `--remote-only`, `--skills`, `--min-score`, `--min-salary`, `--max-results`
- Scan command (`nerajob scan`) merges preset values when flags not explicitly provided
- New `ScanPreset` model + `load_scan_preset`/`save_scan_preset` storage functions
- Tests for preset roundtrip

### [#19] CLI: scan --all aggregates multi-source with dedupe by URL/title+company [25 MRG]
- Always deduplicates across sources (not just with `--all`)
- Reports: "X fetched → Y unique (dropped Z duplicates)"
- Table shows "Jobs saved (X new/updated, Y total)"
- Added skill filter support (`--skills`) for filtering by tag/description word

Total: 75 MRG