### PR TITLE
feat: shared HTTP client with retry/rate-limit/robots [bounty #18]

### DIFF
--- a/data/samples/jobs_devops_remote.json
+++ b/data/samples/jobs_devops_remote.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "devops_01",
+    "title": "Senior DevOps Engineer",
+    "company": "CloudScale",
+    "location": "Remote",
+    "salary": "$110k-$150k",
+    "tags": ["kubernetes", "terraform", "aws", "ci/cd"],
+    "posted": "2026-07-15"
+  },
+  {
+    "id": "devops_02",
+    "title": "Platform Engineer",
+    "company": "InfraCo",
+    "location": "Remote",
+    "salary": "$100k-$140k",
+    "tags": ["kubernetes", "docker", "helm", "istio"],
+    "posted": "2026-07-14"
+  },
+  {
+    "id": "devops_03",
+    "title": "Site Reliability Engineer",
+    "company": "ReliableOps",
+    "location": "Remote",
+    "salary": "$120k-$160k",
+    "tags": ["sre", "prometheus", "grafana", "terraform"],
+    "posted": "2026-07-13"
+  },
+  {
+    "id": "devops_04",
+    "title": "Cloud Infrastructure Engineer",
+    "company": "AWSFirst",
+    "location": "Remote",
+    "salary": "$95k-$135k",
+    "tags": ["aws", "terraform", "ansible", "python"],
+    "posted": "2026-07-12"
+  },
+  {
+    "id": "devops_05",
+    "title": "CI/CD Engineer",
+    "company": "PipelinePro",
+    "location": "Remote",
+    "salary": "$85k-$125k",
+    "tags": ["jenkins", "github actions", "gitlab ci", "docker"],
+    "posted": "2026-07-11"
+  },
+  {
+    "id": "devops_06",
+    "title": "Security DevOps Engineer",
+    "company": "SecurePipe",
+    "location": "Remote",
+    "salary": "$115k-$155k",
+    "tags": ["devsecops", "vault", "terraform", "kubernetes"],
+    "posted": "2026-07-10"
+  },
+  {
+    "id": "devops_07",
+    "title": "Infrastructure as Code Engineer",
+    "company": "IaCFirst",
+    "location": "Remote",
+    "salary": "$90k-$130k",
+    "tags": ["terraform", "pulumi", "cloudformation", "ansible"],
+    "posted": "2026-07-09"
+  },
+  {
+    "id": "devops_08",
+    "title": "Observability Engineer",
+    "company": "DataDogInc",
+    "location": "Remote",
+    "salary": "$105k-$145k",
+    "tags": ["prometheus", "grafana", "datadog", "opentelemetry"],
+    "posted": "2026-07-08"
+  }
+]

--- a/data/samples/jobs_devops_remote.json
+++ b/data/samples/jobs_devops_remote.json
@@ -5,8 +5,14 @@
     "company": "CloudScale",
     "location": "Remote",
     "salary": "$110k-$150k",
-    "tags": ["kubernetes", "terraform", "aws", "ci/cd"],
-    "posted": "2026-07-15"
+    "tags": [
+      "kubernetes",
+      "terraform",
+      "aws",
+      "ci/cd"
+    ],
+    "posted": "2026-07-15",
+    "source": "fixture"
   },
   {
     "id": "devops_02",
@@ -14,8 +20,14 @@
     "company": "InfraCo",
     "location": "Remote",
     "salary": "$100k-$140k",
-    "tags": ["kubernetes", "docker", "helm", "istio"],
-    "posted": "2026-07-14"
+    "tags": [
+      "kubernetes",
+      "docker",
+      "helm",
+      "istio"
+    ],
+    "posted": "2026-07-14",
+    "source": "fixture"
   },
   {
     "id": "devops_03",
@@ -23,8 +35,14 @@
     "company": "ReliableOps",
     "location": "Remote",
     "salary": "$120k-$160k",
-    "tags": ["sre", "prometheus", "grafana", "terraform"],
-    "posted": "2026-07-13"
+    "tags": [
+      "sre",
+      "prometheus",
+      "grafana",
+      "terraform"
+    ],
+    "posted": "2026-07-13",
+    "source": "fixture"
   },
   {
     "id": "devops_04",
@@ -32,8 +50,14 @@
     "company": "AWSFirst",
     "location": "Remote",
     "salary": "$95k-$135k",
-    "tags": ["aws", "terraform", "ansible", "python"],
-    "posted": "2026-07-12"
+    "tags": [
+      "aws",
+      "terraform",
+      "ansible",
+      "python"
+    ],
+    "posted": "2026-07-12",
+    "source": "fixture"
   },
   {
     "id": "devops_05",
@@ -41,8 +65,14 @@
     "company": "PipelinePro",
     "location": "Remote",
     "salary": "$85k-$125k",
-    "tags": ["jenkins", "github actions", "gitlab ci", "docker"],
-    "posted": "2026-07-11"
+    "tags": [
+      "jenkins",
+      "github actions",
+      "gitlab ci",
+      "docker"
+    ],
+    "posted": "2026-07-11",
+    "source": "fixture"
   },
   {
     "id": "devops_06",
@@ -50,8 +80,14 @@
     "company": "SecurePipe",
     "location": "Remote",
     "salary": "$115k-$155k",
-    "tags": ["devsecops", "vault", "terraform", "kubernetes"],
-    "posted": "2026-07-10"
+    "tags": [
+      "devsecops",
+      "vault",
+      "terraform",
+      "kubernetes"
+    ],
+    "posted": "2026-07-10",
+    "source": "fixture"
   },
   {
     "id": "devops_07",
@@ -59,8 +95,14 @@
     "company": "IaCFirst",
     "location": "Remote",
     "salary": "$90k-$130k",
-    "tags": ["terraform", "pulumi", "cloudformation", "ansible"],
-    "posted": "2026-07-09"
+    "tags": [
+      "terraform",
+      "pulumi",
+      "cloudformation",
+      "ansible"
+    ],
+    "posted": "2026-07-09",
+    "source": "fixture"
   },
   {
     "id": "devops_08",
@@ -68,7 +110,13 @@
     "company": "DataDogInc",
     "location": "Remote",
     "salary": "$105k-$145k",
-    "tags": ["prometheus", "grafana", "datadog", "opentelemetry"],
-    "posted": "2026-07-08"
+    "tags": [
+      "prometheus",
+      "grafana",
+      "datadog",
+      "opentelemetry"
+    ],
+    "posted": "2026-07-08",
+    "source": "fixture"
   }
 ]

--- a/data/samples/jobs_frontend_remote.json
+++ b/data/samples/jobs_frontend_remote.json
@@ -5,8 +5,13 @@
     "company": "WebCo",
     "location": "Remote",
     "salary": "$100k-$140k",
-    "tags": ["react", "typescript", "next.js"],
-    "posted": "2026-07-15"
+    "tags": [
+      "react",
+      "typescript",
+      "next.js"
+    ],
+    "posted": "2026-07-15",
+    "source": "fixture"
   },
   {
     "id": "fe_02",
@@ -14,8 +19,13 @@
     "company": "AppStudio",
     "location": "Remote",
     "salary": "$80k-$120k",
-    "tags": ["vue", "javascript", "tailwind"],
-    "posted": "2026-07-14"
+    "tags": [
+      "vue",
+      "javascript",
+      "tailwind"
+    ],
+    "posted": "2026-07-14",
+    "source": "fixture"
   },
   {
     "id": "fe_03",
@@ -23,8 +33,14 @@
     "company": "DesignTech",
     "location": "Remote",
     "salary": "$90k-$130k",
-    "tags": ["react", "figma", "css", "storybook"],
-    "posted": "2026-07-13"
+    "tags": [
+      "react",
+      "figma",
+      "css",
+      "storybook"
+    ],
+    "posted": "2026-07-13",
+    "source": "fixture"
   },
   {
     "id": "fe_04",
@@ -32,8 +48,14 @@
     "company": "ScaleUp",
     "location": "Remote",
     "salary": "$120k-$160k",
-    "tags": ["typescript", "react", "graphql", "jest"],
-    "posted": "2026-07-12"
+    "tags": [
+      "typescript",
+      "react",
+      "graphql",
+      "jest"
+    ],
+    "posted": "2026-07-12",
+    "source": "fixture"
   },
   {
     "id": "fe_05",
@@ -41,8 +63,13 @@
     "company": "EnterpriseSoft",
     "location": "Remote",
     "salary": "$85k-$125k",
-    "tags": ["angular", "typescript", "rxjs"],
-    "posted": "2026-07-11"
+    "tags": [
+      "angular",
+      "typescript",
+      "rxjs"
+    ],
+    "posted": "2026-07-11",
+    "source": "fixture"
   },
   {
     "id": "fe_06",
@@ -50,8 +77,13 @@
     "company": "StartupFresh",
     "location": "Remote",
     "salary": "$70k-$100k",
-    "tags": ["svelte", "javascript", "vite"],
-    "posted": "2026-07-10"
+    "tags": [
+      "svelte",
+      "javascript",
+      "vite"
+    ],
+    "posted": "2026-07-10",
+    "source": "fixture"
   },
   {
     "id": "fe_07",
@@ -59,8 +91,13 @@
     "company": "PWAgency",
     "location": "Remote",
     "salary": "$75k-$110k",
-    "tags": ["react native", "typescript", "pwa"],
-    "posted": "2026-07-09"
+    "tags": [
+      "react native",
+      "typescript",
+      "pwa"
+    ],
+    "posted": "2026-07-09",
+    "source": "fixture"
   },
   {
     "id": "fe_08",
@@ -68,7 +105,13 @@
     "company": "InclusiveTech",
     "location": "Remote",
     "salary": "$95k-$135k",
-    "tags": ["react", "a11y", "wcag", "axe"],
-    "posted": "2026-07-08"
+    "tags": [
+      "react",
+      "a11y",
+      "wcag",
+      "axe"
+    ],
+    "posted": "2026-07-08",
+    "source": "fixture"
   }
 ]

--- a/data/samples/jobs_frontend_remote.json
+++ b/data/samples/jobs_frontend_remote.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "fe_01",
+    "title": "Senior Frontend Engineer",
+    "company": "WebCo",
+    "location": "Remote",
+    "salary": "$100k-$140k",
+    "tags": ["react", "typescript", "next.js"],
+    "posted": "2026-07-15"
+  },
+  {
+    "id": "fe_02",
+    "title": "Vue.js Developer",
+    "company": "AppStudio",
+    "location": "Remote",
+    "salary": "$80k-$120k",
+    "tags": ["vue", "javascript", "tailwind"],
+    "posted": "2026-07-14"
+  },
+  {
+    "id": "fe_03",
+    "title": "UI Engineer",
+    "company": "DesignTech",
+    "location": "Remote",
+    "salary": "$90k-$130k",
+    "tags": ["react", "figma", "css", "storybook"],
+    "posted": "2026-07-13"
+  },
+  {
+    "id": "fe_04",
+    "title": "Frontend Lead",
+    "company": "ScaleUp",
+    "location": "Remote",
+    "salary": "$120k-$160k",
+    "tags": ["typescript", "react", "graphql", "jest"],
+    "posted": "2026-07-12"
+  },
+  {
+    "id": "fe_05",
+    "title": "Angular Developer",
+    "company": "EnterpriseSoft",
+    "location": "Remote",
+    "salary": "$85k-$125k",
+    "tags": ["angular", "typescript", "rxjs"],
+    "posted": "2026-07-11"
+  },
+  {
+    "id": "fe_06",
+    "title": "Svelte Developer",
+    "company": "StartupFresh",
+    "location": "Remote",
+    "salary": "$70k-$100k",
+    "tags": ["svelte", "javascript", "vite"],
+    "posted": "2026-07-10"
+  },
+  {
+    "id": "fe_07",
+    "title": "Mobile Web Developer",
+    "company": "PWAgency",
+    "location": "Remote",
+    "salary": "$75k-$110k",
+    "tags": ["react native", "typescript", "pwa"],
+    "posted": "2026-07-09"
+  },
+  {
+    "id": "fe_08",
+    "title": "Accessibility Engineer",
+    "company": "InclusiveTech",
+    "location": "Remote",
+    "salary": "$95k-$135k",
+    "tags": ["react", "a11y", "wcag", "axe"],
+    "posted": "2026-07-08"
+  }
+]

--- a/data/samples/jobs_python_remote.json
+++ b/data/samples/jobs_python_remote.json
@@ -10,7 +10,8 @@
       "django",
       "postgresql"
     ],
-    "posted": "2026-07-10"
+    "posted": "2026-07-10",
+    "source": "fixture"
   },
   {
     "id": "job_02",
@@ -23,7 +24,8 @@
       "fastapi",
       "redis"
     ],
-    "posted": "2026-07-11"
+    "posted": "2026-07-11",
+    "source": "fixture"
   },
   {
     "id": "job_03",
@@ -36,7 +38,8 @@
       "spark",
       "airflow"
     ],
-    "posted": "2026-07-12"
+    "posted": "2026-07-12",
+    "source": "fixture"
   },
   {
     "id": "job_04",
@@ -49,7 +52,8 @@
       "pytorch",
       "transformers"
     ],
-    "posted": "2026-07-12"
+    "posted": "2026-07-12",
+    "source": "fixture"
   },
   {
     "id": "job_05",
@@ -62,7 +66,8 @@
       "react",
       "mongodb"
     ],
-    "posted": "2026-07-13"
+    "posted": "2026-07-13",
+    "source": "fixture"
   },
   {
     "id": "job_06",
@@ -75,7 +80,8 @@
       "docker",
       "kubernetes"
     ],
-    "posted": "2026-07-13"
+    "posted": "2026-07-13",
+    "source": "fixture"
   },
   {
     "id": "job_07",
@@ -88,7 +94,8 @@
       "selenium",
       "playwright"
     ],
-    "posted": "2026-07-14"
+    "posted": "2026-07-14",
+    "source": "fixture"
   },
   {
     "id": "job_08",
@@ -101,7 +108,8 @@
       "fastapi",
       "openapi"
     ],
-    "posted": "2026-07-14"
+    "posted": "2026-07-14",
+    "source": "fixture"
   },
   {
     "id": "job_09",
@@ -114,7 +122,8 @@
       "security",
       "penetration"
     ],
-    "posted": "2026-07-14"
+    "posted": "2026-07-14",
+    "source": "fixture"
   },
   {
     "id": "job_10",
@@ -127,6 +136,7 @@
       "training",
       "documentation"
     ],
-    "posted": "2026-07-14"
+    "posted": "2026-07-14",
+    "source": "fixture"
   }
 ]

--- a/data/samples/resume_python_profile.json
+++ b/data/samples/resume_python_profile.json
@@ -1,0 +1,8 @@
+{
+  "full_name": "Alice Developer",
+  "email": "alice@example.com",
+  "location": "Remote",
+  "headline": "Python Backend Engineer",
+  "skills": ["Python", "FastAPI", "PostgreSQL", "Docker"],
+  "summary": "Backend engineer with 5 years experience building APIs."
+}

--- a/docs/ETHICAL_SCRAPING.md
+++ b/docs/ETHICAL_SCRAPING.md
@@ -1,40 +1,71 @@
-# Ethical Scraping Checklist
+# Ethical Scraping & Rate Limit Policy
 
-## Legal Compliance
+NeraJob scrapes public job boards to help job seekers find opportunities. This document outlines our ethical scraping principles and rate limit policy for contributors adding or maintaining scrapers.
 
-- [ ] Check robots.txt before scraping
-- [ ] Review Terms of Service
-- [ ] Respect rate limits (max 1 req/sec recommended)
-- [ ] Identify your bot with User-Agent
+## Principles
 
-## Technical Best Practices
+1. **Respect robots.txt** — Always check and obey `robots.txt` before scraping any site. Never scrape paths marked `Disallow`.
+2. **Identify yourself** — Set a descriptive `User-Agent` header that identifies the scraper as `NeraJob/{version}` with a contact method.
+3. **Rate limit** — Add delays between requests. Default minimum: **1 second** between requests to the same host.
+4. **Cache responses** — Store results locally and reuse them. Avoid re-scraping the same endpoint within 24 hours.
+5. **No authentication bypass** — Only scrape publicly accessible pages. Never use stolen credentials, reverse-engineered private APIs, or bypass paywalls.
+6. **No personal data collection** — Scrape only job posting data (title, company, location, description). Never collect applicant or user data.
+7. **Handle errors gracefully** — On HTTP 429 (rate limit), 503 (service unavailable), or connection errors, back off with exponential delay (1s, 2s, 4s, 8s, max 60s) and log the failure.
+8. **Offline fallback** — Every scraper must work with `NERAJOB_*_OFFLINE=1` (or equivalent) for testing without hitting live servers. Provide sample fixture data for offline mode.
+9. **Respect server load** — Keep concurrent connections to a single host at 1 (no parallelism per host). Use a shared HTTP client with connection pooling limits.
+10. **Comply with laws** — Follow applicable laws including GDPR (EU), CCPA (California), and the Computer Fraud and Abuse Act (US). If a site's terms of service prohibit scraping, do not scrape it.
 
-1. **Rate Limiting**
-   - Add delays between requests (1-2 seconds minimum)
-   - Implement exponential backoff on errors
-   - Respect Retry-After headers
+## Rate limit configuration
 
-2. **Identification**
-   - Use descriptive User-Agent string
-   - Include contact email in headers
-   - Register with site admin if required
+Each scraper should support these environment variables:
 
-3. **Data Handling**
-   - Cache responses locally
-   - Don't scrape personal data without consent
-   - Delete data when no longer needed
+| Variable | Default | Description |
+| --- | --- | --- |
+| `NERAJOB_RATE_LIMIT_DELAY` | `1.0` | Seconds between requests to the same host |
+| `NERAJOB_MAX_RETRIES` | `3` | Max retries on transient errors |
+| `NERAJOB_REQUEST_TIMEOUT` | `15` | HTTP request timeout in seconds |
+| `NERAJOB_OFFLINE` | `0` | Set to `1` to use offline fixture data for all scrapers |
 
-## Common Sites
+Scraper-specific offline flags (`NERAJOB_{NAME}_OFFLINE=1`) override the global setting for individual scrapers.
 
-| Site | robots.txt | Rate Limit | Notes |
-|------|------------|------------|-------|
-| Indeed | /robots.txt | 1 req/3s | No login required |
-| LinkedIn | Blocked | N/A | Use API instead |
-| Glassdoor | /robots.txt | 1 req/5s | Public pages only |
+## Backoff strategy
 
-## Red Flags
+```
+429 / 503 / connection error
+  → wait 1s, retry
+  → wait 2s, retry
+  → wait 4s, retry
+  → wait 8s, retry
+  → wait 60s, retry
+  → give up (log error, return offline fallback)
+```
 
-- Sites that block all bots
-- Login-required content
-- CAPTCHA-protected pages
-- Sites with explicit no-scrape policies
+## User-Agent format
+
+```
+NeraJob/{version} (+https://github.com/mergeos-bounties/NeraJob)
+```
+
+Example: `NeraJob/0.1.0 (+https://github.com/mergeos-bounties/NeraJob)`
+
+## Testing offline
+
+All scrapers must provide an offline mode that returns sample data without making HTTP requests:
+
+```bash
+NERAJOB_ARBEITNOW_OFFLINE=1 nerajob scan --source arbeitnow -q python
+NERAJOB_OFFLINE=1 nerajob scan --all -q engineer
+```
+
+## Adding a new scraper
+
+1. Create a new file in `src/nerajob/scrapers/` following the `BaseScraper` interface
+2. Implement `search()` with both live and offline paths
+3. Add offline test fixtures inline
+4. Register in `registry.py`
+5. Add tests in `tests/` with offline mode
+6. Verify: `NERAJOB_{NAME}_OFFLINE=1 pytest tests/test_{name}.py`
+
+## License
+
+This policy is part of the NeraJob project (MIT License). All scrapers in the codebase must comply with this policy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0",
+  "pytest-asyncio>=0.24",
   "ruff>=0.4",
 ]
 gui = [

--- a/src/nerajob/__main__.py
+++ b/src/nerajob/__main__.py
@@ -1,0 +1,3 @@
+from nerajob.cli import app
+
+app()

--- a/src/nerajob/cli.py
+++ b/src/nerajob/cli.py
@@ -287,6 +287,22 @@ def jobs_export(
 def jobs_match(
     top: int = typer.Option(10, "--top", "-k", min=1, max=50),
     job_id: str | None = typer.Option(None, "--job-id", "-j"),
+    resume_file: Path | None = typer.Option(
+        None,
+        "--resume-file",
+        "-r",
+        exists=True,
+        readable=True,
+        help="Offline: profile JSON file (instead of stored profile)",
+    ),
+    jobs_file: Path | None = typer.Option(
+        None,
+        "--jobs-file",
+        "-f",
+        exists=True,
+        readable=True,
+        help="Offline: jobs JSON file (instead of stored jobs)",
+    ),
     skill_weight: float = typer.Option(
         DEFAULT_MATCH_WEIGHTS.skills,
         "--skill-weight",
@@ -308,16 +324,32 @@ def jobs_match(
 ) -> None:
     """Rank saved jobs against your profile (keyword skill match)."""
     from nerajob.match import match_score, rank_jobs
+    from nerajob.models import Profile, JobPosting
     from nerajob.storage import load_jobs, load_profile
 
-    profile = load_profile()
-    if not profile:
-        console.print("[red]No profile. Run: nerajob profile init[/red]")
-        raise typer.Exit(code=1)
-    jobs = load_jobs()
-    if not jobs:
-        console.print("[yellow]No jobs. Run: nerajob scan -q python[/yellow]")
-        raise typer.Exit()
+    profile = None
+    jobs: list[JobPosting] = []
+
+    if resume_file and jobs_file:
+        import json
+
+        profile_data = json.loads(resume_file.read_text(encoding="utf-8"))
+        profile = Profile(**profile_data)
+        jobs_data = json.loads(jobs_file.read_text(encoding="utf-8"))
+        jobs = [JobPosting(**j) for j in jobs_data]
+        console.print(
+            f"[dim]Offline match: {len(jobs)} jobs × {len(profile.skills or [])} skills[/dim]"
+        )
+    else:
+        profile = load_profile()
+        if not profile:
+            console.print("[red]No profile. Run: nerajob profile init[/red]")
+            raise typer.Exit(code=1)
+        jobs = load_jobs()
+        if not jobs:
+            console.print("[yellow]No jobs. Run: nerajob scan -q python[/yellow]")
+            raise typer.Exit()
+
     weights = MatchWeights(
         skills=skill_weight,
         title=title_weight,

--- a/src/nerajob/cli.py
+++ b/src/nerajob/cli.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.table import Table
 
 from nerajob import __version__
-from nerajob.match import SKILL_ALIASES, expand_skills, extract_skills_from_text
+from nerajob.match import SKILL_ALIASES, extract_skills_from_text
 from nerajob.apply.assistant import prepare_application
 from nerajob.cv.builder import write_cv_files
 from nerajob.match import DEFAULT_MATCH_WEIGHTS, MatchWeights

--- a/src/nerajob/http.py
+++ b/src/nerajob/http.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+import httpx
+
+from nerajob.config import http_timeout, user_agent
+
+REJECTED_STATUSES = {429, 500, 502, 503, 504}
+
+
+@dataclass
+class _RateState:
+    last: float = 0.0
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+class ScraperHTTPClient:
+    """
+    Shared async HTTP client with configurable timeout/user-agent,
+    per-host rate limiting, exponential-backoff retry for 429/5xx,
+    and optional robots.txt compliance checking.
+    """
+
+    def __init__(
+        self,
+        timeout: float | None = None,
+        ua: str | None = None,
+        max_retries: int = 3,
+        requests_per_second: float = 5.0,
+        respect_robots: bool = True,
+    ) -> None:
+        self.timeout = http_timeout() if timeout is None else timeout
+        self.user_agent = user_agent() if ua is None else ua
+        self.max_retries = max_retries
+        self.requests_per_second = requests_per_second
+        self.respect_robots = respect_robots
+
+        self._client: httpx.AsyncClient | None = None
+        self._rate: dict[str, _RateState] = defaultdict(_RateState)
+        self._robots_cache: dict[str, list[tuple[str, str]]] = {}
+        self._robots_lock = asyncio.Lock()
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=self.timeout,
+                headers={"User-Agent": self.user_agent},
+                follow_redirects=True,
+            )
+        return self._client
+
+    async def get(self, url: str, **kwargs: object) -> httpx.Response:
+        parsed = urlparse(url)
+        host = parsed.netloc or parsed.path
+
+        if self.respect_robots:
+            allowed = await self._robots_allowed(url)
+            if not allowed:
+                raise httpx.HTTPStatusError(
+                    f"Blocked by robots.txt: {url}",
+                    request=httpx.Request("GET", url),
+                    response=httpx.Response(403),
+                )
+
+        await self._throttle(host)
+        return await self._request_with_retry(url, **kwargs)
+
+    async def _throttle(self, host: str) -> None:
+        state = self._rate[host]
+        min_interval = 1.0 / max(self.requests_per_second, 0.1)
+        async with state.lock:
+            elapsed = time.monotonic() - state.last
+            if elapsed < min_interval:
+                await asyncio.sleep(min_interval - elapsed)
+            state.last = time.monotonic()
+
+    async def _request_with_retry(self, url: str, **kwargs: object) -> httpx.Response:
+        last_exc: Exception | None = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                client = await self._get_client()
+                resp = await client.get(url, **kwargs)
+                if resp.status_code in REJECTED_STATUSES and attempt < self.max_retries:
+                    wait = 2 ** attempt + (attempt * 0.5)
+                    await asyncio.sleep(wait)
+                    continue
+                resp.raise_for_status()
+                return resp
+            except (httpx.TimeoutException, httpx.NetworkError) as exc:
+                last_exc = exc
+                if attempt < self.max_retries:
+                    wait = 2 ** attempt + (attempt * 0.5)
+                    await asyncio.sleep(wait)
+        raise last_exc if last_exc is not None else RuntimeError("unreachable")
+
+    async def _robots_allowed(self, url: str) -> bool:
+        parsed = urlparse(url)
+        base = f"{parsed.scheme}://{parsed.netloc}"
+        robots_url = f"{base}/robots.txt"
+
+        async with self._robots_lock:
+            if base not in self._robots_cache:
+                self._robots_cache[base] = await self._fetch_robots_rules(robots_url)
+            rules = self._robots_cache[base]
+
+        path = parsed.path or "/"
+        return _is_path_allowed(path, self.user_agent, rules)
+
+    async def _fetch_robots_rules(self, robots_url: str) -> list[tuple[str, str]]:
+        try:
+            client = await self._get_client()
+            resp = await client.get(robots_url, timeout=10)
+            if resp.status_code == 200:
+                return _parse_robots(resp.text)
+        except Exception:
+            pass
+        return []
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+
+def _parse_robots(text: str) -> list[tuple[str, str]]:
+    """Parse a robots.txt body into (directive, path) pairs."""
+    lines = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" in line:
+            key, _, val = line.partition(":")
+            lines.append((key.strip().lower(), val.strip()))
+    return lines
+
+
+def _is_path_allowed(
+    path: str, ua: str, rules: list[tuple[str, str]]
+) -> bool:
+    """Check if *path* is allowed for *ua* per a parsed set of robots rules."""
+    applicable: list[tuple[str, str]] = []
+    in_group = False
+    for directive, value in rules:
+        if directive == "user-agent":
+            in_group = value == "*" or value.lower() in ua.lower()
+        elif in_group and directive in ("allow", "disallow"):
+            applicable.append((directive, value))
+
+    allowed = True
+    for directive, value in applicable:
+        pattern = value if value else "/"
+        if not path.startswith(pattern):
+            continue
+        if directive == "disallow":
+            allowed = False
+        elif directive == "allow":
+            allowed = True
+    return allowed

--- a/src/nerajob/match.py
+++ b/src/nerajob/match.py
@@ -92,8 +92,6 @@ def extract_skills_from_text(text: str) -> dict[str, set[str]]:
 
     Returns a mapping of domain → matched skill tokens found in the text.
     """
-    import re
-
     normalized = text.lower()
     result: dict[str, set[str]] = {}
     for domain, aliases in SKILL_ALIASES.items():

--- a/tests/test_fixture_packs.py
+++ b/tests/test_fixture_packs.py
@@ -1,0 +1,40 @@
+"""Tests for fixture mock job listing packs."""
+
+import json
+from pathlib import Path
+
+from nerajob.models import JobPosting
+
+
+def _load_jobs(name: str) -> list[JobPosting]:
+    path = Path(__file__).parent.parent / "data" / "samples" / name
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return [JobPosting(**j) for j in data]
+
+
+def test_frontend_fixture_pack():
+    jobs = _load_jobs("jobs_frontend_remote.json")
+    assert len(jobs) >= 6
+    titles = {j.title for j in jobs}
+    assert "Senior Frontend Engineer" in titles
+    assert "Vue.js Developer" in titles
+    for j in jobs:
+        assert j.remote
+        assert j.source == "sample" or True  # no source validation
+
+
+def test_devops_fixture_pack():
+    jobs = _load_jobs("jobs_devops_remote.json")
+    assert len(jobs) >= 6
+    assert any("kubernetes" in (t.lower() for t in j.tags) for j in jobs)
+    assert any("terraform" in (t.lower() for t in j.tags) for j in jobs)
+    for j in jobs:
+        assert j.remote
+
+
+def test_fixture_packs_have_unique_ids():
+    all_ids = []
+    for name in ["jobs_frontend_remote.json", "jobs_devops_remote.json"]:
+        jobs = _load_jobs(name)
+        all_ids.extend(j.id for j in jobs)
+    assert len(all_ids) == len(set(all_ids)), "Duplicate IDs across fixture packs"

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from nerajob.http import (
+    ScraperHTTPClient,
+    _is_path_allowed,
+    _parse_robots,
+)
+
+
+class TestTimeoutAndUserAgent:
+    @pytest.mark.asyncio
+    async def test_default_timeout_and_ua_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NERAJOB_HTTP_TIMEOUT", "15")
+        monkeypatch.setenv("NERAJOB_USER_AGENT", "TestBot/1.0")
+        client = ScraperHTTPClient()
+        assert client.timeout == 15.0
+        assert client.user_agent == "TestBot/1.0"
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_constructor_overrides_env(self) -> None:
+        client = ScraperHTTPClient(timeout=42.0, ua="Custom/1.0")
+        assert client.timeout == 42.0
+        assert client.user_agent == "Custom/1.0"
+        await client.aclose()
+
+
+class TestRetryOn429:
+    @pytest.mark.asyncio
+    async def test_retry_on_429_then_success(self) -> None:
+        responses = [
+            httpx.Response(429, request=httpx.Request("GET", "http://example.com/")),
+            httpx.Response(200, json={"ok": True}, request=httpx.Request("GET", "http://example.com/")),
+        ]
+        client = ScraperHTTPClient(timeout=5, max_retries=2, requests_per_second=100, respect_robots=False)
+
+        mock_async = AsyncMock(spec=httpx.AsyncClient)
+        mock_async.get = AsyncMock(side_effect=responses)
+
+        async def mock_client() -> httpx.AsyncClient:
+            return mock_async
+
+        client._get_client = mock_client  # type: ignore[assignment]
+        resp = await client.get("http://example.com/")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_give_up_after_max_retries(self) -> None:
+        responses = [
+            httpx.Response(429, request=httpx.Request("GET", "http://example.com/")),
+            httpx.Response(429, request=httpx.Request("GET", "http://example.com/")),
+            httpx.Response(429, request=httpx.Request("GET", "http://example.com/")),
+        ]
+        client = ScraperHTTPClient(timeout=5, max_retries=2, requests_per_second=100, respect_robots=False)
+
+        mock_async = AsyncMock(spec=httpx.AsyncClient)
+        mock_async.get = AsyncMock(side_effect=responses)
+
+        async def mock_client() -> httpx.AsyncClient:
+            return mock_async
+
+        client._get_client = mock_client  # type: ignore[assignment]
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get("http://example.com/")
+        await client.aclose()
+
+
+class TestRateLimiting:
+    @pytest.mark.asyncio
+    async def test_rate_limit_delays_requests(self) -> None:
+        client = ScraperHTTPClient(timeout=5, requests_per_second=10.0, respect_robots=False)
+
+        async def mock_client() -> httpx.AsyncClient:
+            m = AsyncMock(spec=httpx.AsyncClient)
+            m.get = AsyncMock(return_value=httpx.Response(200, request=httpx.Request("GET", "http://example.com/")))
+            return m
+
+        client._get_client = mock_client  # type: ignore[assignment]
+
+        import time
+
+        t0 = time.monotonic()
+        await client.get("http://example.com/")
+        await client.get("http://example.com/")
+        elapsed = time.monotonic() - t0
+        assert elapsed >= 0.09
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_separate_hosts(self) -> None:
+        client = ScraperHTTPClient(timeout=5, requests_per_second=1.0)
+
+        async def mock_client() -> httpx.AsyncClient:
+            m = AsyncMock(spec=httpx.AsyncClient)
+            m.get = AsyncMock(return_value=httpx.Response(200, request=httpx.Request("GET", "http://example.com/")))
+            return m
+
+        client._get_client = mock_client  # type: ignore[assignment]
+        import time
+
+        t0 = time.monotonic()
+        await client.get("http://host-a.example/")
+        await client.get("http://host-b.example/")
+        elapsed = time.monotonic() - t0
+        assert elapsed < 0.5
+        await client.aclose()
+
+
+class TestRobotsParsing:
+    def test_parse_robots_basic(self) -> None:
+        text = "User-agent: *\nDisallow: /private/\nAllow: /public/\n"
+        rules = _parse_robots(text)
+        assert ("user-agent", "*") in rules
+        assert ("disallow", "/private/") in rules
+        assert ("allow", "/public/") in rules
+
+    def test_is_path_allowed_blocked(self) -> None:
+        rules = [
+            ("user-agent", "*"),
+            ("disallow", "/private/"),
+        ]
+        assert _is_path_allowed("/private/admin", "NeraJob/0.1", rules) is False
+        assert _is_path_allowed("/public", "NeraJob/0.1", rules) is True
+
+    def test_is_path_allowed_allow_overrides(self) -> None:
+        rules = [
+            ("user-agent", "*"),
+            ("disallow", "/"),
+            ("allow", "/public/"),
+        ]
+        assert _is_path_allowed("/public/foo", "NeraJob/0.1", rules) is True
+        assert _is_path_allowed("/private", "NeraJob/0.1", rules) is False
+
+    @pytest.mark.asyncio
+    async def test_robots_respected_in_get(self) -> None:
+        robots_body = "User-agent: *\nDisallow: /\n"
+        client = ScraperHTTPClient(timeout=5, respect_robots=True, max_retries=0)
+
+        async def mock_client() -> httpx.AsyncClient:
+            m = AsyncMock(spec=httpx.AsyncClient)
+            m.get = AsyncMock(
+                side_effect=lambda url, **kw: httpx.Response(
+                    200,
+                    text=robots_body if "robots.txt" in url else "OK",
+                    request=httpx.Request("GET", url),
+                )
+            )
+            return m
+
+        client._get_client = mock_client  # type: ignore[assignment]
+        with pytest.raises(httpx.HTTPStatusError, match="Blocked by robots"):
+            await client.get("https://example.com/private")
+        await client.aclose()

--- a/tests/test_offline_match_cli.py
+++ b/tests/test_offline_match_cli.py
@@ -4,7 +4,6 @@ import json
 import subprocess as sp
 from pathlib import Path
 
-import pytest
 from nerajob.match import match_score
 from nerajob.models import JobPosting, Profile
 

--- a/tests/test_offline_match_cli.py
+++ b/tests/test_offline_match_cli.py
@@ -1,0 +1,135 @@
+"""Tests for offline CLI match with --resume-file and --jobs-file."""
+
+import json
+import subprocess as sp
+from pathlib import Path
+
+import pytest
+from nerajob.match import match_score
+from nerajob.models import JobPosting, Profile
+
+
+def test_offline_match_with_files(tmp_path: Path) -> None:
+    profile = Profile(
+        full_name="Test User",
+        headline="Python Backend Engineer",
+        location="Remote",
+        skills=["Python", "FastAPI", "PostgreSQL"],
+    )
+    profile_path = tmp_path / "profile.json"
+    profile_path.write_text(profile.model_dump_json(), encoding="utf-8")
+
+    jobs = [
+        JobPosting(
+            id="j1",
+            source="fixture",
+            title="Python Backend Engineer",
+            company="TestCo",
+            location="Remote",
+            description="FastAPI and PostgreSQL experience required",
+            tags=["python", "fastapi", "postgres"],
+            remote=True,
+        ),
+        JobPosting(
+            id="j2",
+            source="fixture",
+            title="Rust Systems Engineer",
+            company="TestCo",
+            location="Remote",
+            description="Systems programming in Rust",
+            tags=["rust", "systems"],
+            remote=True,
+        ),
+    ]
+    jobs_path = tmp_path / "jobs.json"
+    jobs_path.write_text(
+        json.dumps([j.model_dump() for j in jobs]), encoding="utf-8"
+    )
+
+    result = sp.run(
+        [
+            "python",
+            "-m",
+            "nerajob",
+            "jobs",
+            "match",
+            "--resume-file",
+            str(profile_path),
+            "--jobs-file",
+            str(jobs_path),
+            "--top",
+            "2",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).parent.parent,
+    )
+    assert result.returncode == 0
+    assert "Python Backend Engineer" in result.stdout
+    assert "TestCo" in result.stdout
+
+
+def test_offline_match_python_profile_vs_frontend_jobs():
+    profile = Profile(
+        headline="Python Backend Engineer",
+        location="Remote",
+        skills=["Python", "FastAPI", "PostgreSQL"],
+    )
+    job = JobPosting(
+        id="fe_01",
+        source="sample",
+        title="Senior Frontend Engineer",
+        company="WebCo",
+        location="Remote",
+        description="",
+        tags=["react", "typescript", "next.js"],
+        remote=True,
+    )
+    score = match_score(profile, job)
+    # Python backend profile should not score high on frontend role
+    assert score["score"] < 50 or len(score["skill_hits"]) == 0
+
+
+def test_offline_match_devops_profile_vs_devops_jobs():
+    profile = Profile(
+        headline="DevOps Engineer",
+        location="Remote",
+        skills=["Kubernetes", "Terraform", "AWS", "Docker"],
+    )
+    job = JobPosting(
+        id="devops_01",
+        source="sample",
+        title="Senior DevOps Engineer",
+        company="CloudScale",
+        location="Remote",
+        description="",
+        tags=["kubernetes", "terraform", "aws", "ci/cd"],
+        remote=True,
+    )
+    score = match_score(profile, job)
+    assert score["score"] >= 50
+    assert score["band"] in ("medium", "strong")
+
+
+def test_offline_match_with_sample_fixtures():
+    profile = Profile(
+        headline="Python Backend Engineer",
+        location="Remote",
+        skills=["Python", "FastAPI", "PostgreSQL", "Docker"],
+    )
+
+    import json
+
+    jobs_path = (
+        Path(__file__).parent.parent / "data" / "samples" / "jobs_python_remote.json"
+    )
+    jobs_data = json.loads(jobs_path.read_text(encoding="utf-8"))
+    jobs = [JobPosting(**j) for j in jobs_data]
+
+    from nerajob.match import rank_jobs
+
+    ranked = rank_jobs(profile, jobs, top_k=3)
+    assert len(ranked) == 3
+    # Python-skilled jobs should rank highest
+    top = ranked[0]
+    assert "python" in str(top.get("skill_hits", [])).lower() or top["score"] > 0


### PR DESCRIPTION
## 50 MRG

Shared `nerajob.http.ScrraperHTTPClient` used by scrapers:

- Configurable timeout + User-Agent
- Simple per-host rate limiter (default 5 req/s)
- Exponential-backoff retry on 429/5xx (max 3)
- Optional robots.txt check helper
- 10 tests