### PR TITLE
feat: add ethical scraping policy documentation (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,11 @@ Contributor guide: **[docs/SKILL_ALIASES.md](docs/SKILL_ALIASES.md)**.
 
 ## Compliance
 
-NeraJob is built for **ethical, ToS-aware** job discovery:
+See [SCRAPING_POLICY.md](docs/SCRAPING_POLICY.md) for ethical scraping guidelines and rate limit policies.
 
+## MergeOS bounties
+
+See [docs/BOUNTY.md](docs/BOUNTY.md) for bounty details.
 - Prefer **official / public APIs** over brittle HTML scrapers
 - Respect **robots.txt**, published rate limits, and site **Terms of Service**
 - **Never** commit secrets, long-lived tokens, or production `.env` values

--- a/docs/SCRAPING_POLICY.md
+++ b/docs/SCRAPING_POLICY.md
@@ -1,0 +1,26 @@
+# Ethical Scraping Policy
+
+## Rate Limits
+
+- Respect the target website's robots.txt
+- Implement delays between requests (minimum 2 seconds)
+- Use exponential backoff for retries
+
+## API Preferences
+
+When available, prefer official APIs over scraping:
+- LinkedIn API
+- Indeed API
+- Glassdoor API
+
+## Data Usage
+
+- Do not collect or store personal information
+- Anonymize all collected data
+- Delete raw data after processing
+
+## Compliance
+
+- Comply with all applicable laws and regulations
+- Provide clear opt-out mechanisms for users
+- Maintain transparency about data collection practices


### PR DESCRIPTION
Fixes mergeos-bounties/NeraJob#53

Added ethical scraping policy documentation with rate limits, API preferences, and compliance guidelines.