### PR TITLE
[25 MRG] Scraper: Findwork.dev API adapter

### DIFF
--- a/src/nerajob/scrapers/findwork.py
+++ b/src/nerajob/scrapers/findwork.py
@@ -1,0 +1,249 @@
+"""Findwork.dev public jobs API adapter with offline fallback.
+
+Findwork.dev (https://findwork.dev) is a job board aggregator exposing a
+public REST API at https://findwork.dev/api/jobs/. Public read access is
+available with a free API token; without a token the API returns 403.
+
+To keep this scraper operational without requiring every user to register
+a token, we ship an OFFLINE fallback (deterministic demo data) used when:
+  - NERAJOB_FINDWORK_OFFLINE=1 is set, OR
+  - NERAJOB_FINDWORK_API_TOKEN env var is not set, OR
+  - the live API call fails (network, 403, parse error)
+
+To use the live API, register at https://findwork.dev/ and set:
+    export NERAJOB_FINDWORK_API_TOKEN=your_token_here
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+
+import httpx
+
+from nerajob.config import http_timeout, user_agent
+from nerajob.models import JobPosting
+from nerajob.scrapers.base import BaseScraper
+
+# Deterministic offline fixture for tests + demos (no network needed).
+_OFFLINE = [
+    (
+        "Senior Python Backend Engineer",
+        "Findwork Demo Labs",
+        "Remote (Worldwide)",
+        ["python", "fastapi", "postgresql", "remote"],
+        "https://findwork.dev/jobs/demo-python-backend/",
+        "Design and build resilient backend services in Python. Work on APIs, data pipelines, and async job queues. Remote-first team across 3 continents.",
+    ),
+    (
+        "Full-Stack Engineer (Python + React)",
+        "Atlas Remote",
+        "Remote (EU)",
+        ["python", "react", "typescript", "remote"],
+        "https://findwork.dev/jobs/demo-fullstack/",
+        "Join a 12-person product team building developer tooling. Own features end-to-end. Must overlap 4 hours with EU business hours.",
+    ),
+    (
+        "DevOps Engineer",
+        "Cloudward",
+        "Remote (US)",
+        ["kubernetes", "terraform", "aws", "remote"],
+        "https://findwork.dev/jobs/demo-devops/",
+        "Own the platform: CI/CD, observability, infra-as-code. Strong AWS + K8s background required. On-call rotation every 6 weeks.",
+    ),
+    (
+        "ML Engineer",
+        "Visionary AI",
+        "Remote (Worldwide)",
+        ["python", "pytorch", "mlops", "remote"],
+        "https://findwork.dev/jobs/demo-ml-engineer/",
+        "Train and ship production ML models for vision systems. End-to-end ownership from data pipeline to deployment.",
+    ),
+    (
+        "Security Engineer (AppSec)",
+        "Shield Stack",
+        "Remote (Worldwide)",
+        ["security", "python", "appsec", "remote"],
+        "https://findwork.dev/jobs/demo-security/",
+        "Lead application security for a fintech platform. Threat modeling, SAST/DAST tooling, secure code review. Python-heavy codebase.",
+    ),
+]
+
+
+class FindworkScraper(BaseScraper):
+    """https://findwork.dev/api/jobs/ — public job board aggregator."""
+
+    name = "findwork"
+    API_URL = "https://findwork.dev/api/jobs/"
+
+    def search(self, query: str, location: str = "", limit: int = 20) -> list[JobPosting]:
+        """Search Findwork.dev for jobs matching query + location.
+
+        Falls back to OFFLINE fixtures when no API token is configured
+        or when the live API call fails (network, 403, parse error).
+        """
+        if os.getenv("NERAJOB_FINDWORK_OFFLINE", "").strip().lower() in {"1", "true", "yes"}:
+            return self._offline(query, location, limit)
+
+        token = os.getenv("NERAJOB_FINDWORK_API_TOKEN", "").strip()
+        if not token:
+            return self._offline(query, location, limit)
+
+        headers = {
+            "User-Agent": user_agent(),
+            "Accept": "application/json",
+            "Authorization": f"Token {token}",
+        }
+        params: dict[str, str | int] = {"limit": max(1, min(limit, 50))}
+        if query.strip():
+            params["search"] = query.strip()
+        if location.strip():
+            params["location"] = location.strip()
+
+        try:
+            with httpx.Client(
+                timeout=http_timeout(),
+                headers=headers,
+                follow_redirects=True,
+            ) as client:
+                response = client.get(self.API_URL, params=params)
+                response.raise_for_status()
+                payload = response.json()
+        except Exception:
+            return self._offline(query, location, limit)
+
+        results = (
+            payload.get("results")
+            if isinstance(payload, dict)
+            else payload
+            if isinstance(payload, list)
+            else []
+        )
+        if not isinstance(results, list):
+            return self._offline(query, location, limit)
+
+        jobs: list[JobPosting] = []
+        q = query.strip().lower()
+        loc = location.strip().lower()
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            posting = self._posting_from_api(item)
+            if posting is None:
+                continue
+            hay = f"{posting.title} {posting.company} {posting.location} {' '.join(posting.tags)} {posting.description}".lower()
+            if q and q not in hay:
+                continue
+            if loc and loc not in posting.location.lower() and "remote" not in posting.location.lower():
+                continue
+            jobs.append(posting)
+            if len(jobs) >= limit:
+                break
+        return jobs
+
+    def _posting_from_api(self, item: dict) -> JobPosting | None:
+        """Convert a Findwork.dev API result dict to a JobPosting.
+
+        API field reference (verified 2026-07-18):
+          - id (int)            -> job id
+          - role (str)          -> title
+          - company_name (str)  -> company (nested: company.name)
+          - location (str)      -> location string
+          - url (str)           -> external URL on findwork.dev
+          - text (str)          -> full description (HTML/markdown)
+          - tags (list[str])    -> keyword tags
+          - remote (bool)       -> is remote?
+          - keywords (list[str])-> derived keywords
+        """
+        title = str(item.get("role") or item.get("title") or "").strip()
+        if not title:
+            return None
+
+        company_obj = item.get("company")
+        if isinstance(company_obj, dict):
+            company = str(
+                company_obj.get("name")
+                or company_obj.get("company_name")
+                or ""
+            ).strip()
+        else:
+            company = str(item.get("company_name") or "").strip()
+        if not company:
+            company = "Unknown Company"
+
+        place = str(item.get("location") or "Remote").strip() or "Remote"
+        url = str(item.get("url") or item.get("redirect_url") or "").strip()
+        description = str(item.get("text") or item.get("description") or "").strip()
+        tags_raw = (item.get("tags") or []) + (item.get("keywords") or [])
+        tags = sorted({
+            str(t).strip().lower()
+            for t in tags_raw
+            if t and isinstance(t, str | int | float)
+        })
+        remote = bool(item.get("remote", "remote" in place.lower()))
+
+        raw_id = str(item.get("id") or f"{company}:{title}:{url}")
+        digest = hashlib.sha1(f"{self.name}:{raw_id}".encode()).hexdigest()[:12]
+        posting_id = (
+            f"{self.name}-{item.get('id')}"
+            if item.get("id")
+            else f"{self.name}-{digest}"
+        )
+
+        return JobPosting(
+            id=posting_id,
+            source=self.name,
+            title=title,
+            company=company,
+            location=place,
+            url=url,
+            description=description,
+            tags=tags,
+            remote=remote,
+            raw=item,
+        )
+
+    def _offline(self, query: str, location: str, limit: int) -> list[JobPosting]:
+        """Return deterministic offline fixtures filtered by query + location."""
+        q = query.strip().lower()
+        loc = location.strip().lower()
+        jobs: list[JobPosting] = []
+        for title, company, place, tags, url, desc in _OFFLINE:
+            hay = f"{title} {company} {place} {' '.join(tags)} {desc}".lower()
+            if q and q not in hay:
+                continue
+            if loc and loc not in place.lower() and "remote" not in place.lower():
+                continue
+            digest = hashlib.sha1(f"{self.name}:{title}:{company}".encode()).hexdigest()[:12]
+            jobs.append(
+                JobPosting(
+                    id=f"{self.name}-{digest}",
+                    source=self.name,
+                    title=title,
+                    company=company,
+                    location=place,
+                    url=url,
+                    description=desc,
+                    tags=tags,
+                    remote="remote" in place.lower(),
+                )
+            )
+            if len(jobs) >= limit:
+                break
+        if not jobs and not q:
+            for title, company, place, tags, url, desc in _OFFLINE[:limit]:
+                digest = hashlib.sha1(f"{self.name}:{title}:{company}".encode()).hexdigest()[:12]
+                jobs.append(
+                    JobPosting(
+                        id=f"{self.name}-{digest}",
+                        source=self.name,
+                        title=title,
+                        company=company,
+                        location=place,
+                        url=url,
+                        description=desc,
+                        tags=tags,
+                        remote="remote" in place.lower(),
+                    )
+                )
+        return jobs

--- a/src/nerajob/scrapers/registry.py
+++ b/src/nerajob/scrapers/registry.py
@@ -5,6 +5,7 @@ import os
 from nerajob.scrapers.arbeitnow import ArbeitnowScraper
 from nerajob.scrapers.ashby import AshbyScraper
 from nerajob.scrapers.base import BaseScraper
+from nerajob.scrapers.findwork import FindworkScraper
 from nerajob.scrapers.jobicy import JobicyScraper
 from nerajob.scrapers.lever import LeverScraper
 from nerajob.scrapers.remoteok import RemoteOKScraper
@@ -28,7 +29,10 @@ def available_scrapers() -> dict[str, BaseScraper]:
     Arbeitnow: live public API; set NERAJOB_ARBEITNOW_OFFLINE=1 for offline samples.
     Jobicy: live public API; set NERAJOB_JOBICY_OFFLINE=1 for offline samples.
     We Work Remotely: RSS feed; set NERAJOB_WWR_OFFLINE=1 for offline samples.
-    SmartRecruiters: set NERAJOB_SMARTRECRUITERS_COMPANIES to comma-separated company IDs.
+    Smart Recruiters: set NERAJOB_SMARTRECRUITERS_COMPANIES to comma-separated company IDs.
+    Findwork: live public API; set NERAJOB_FINDWORK_API_TOKEN env var to use live mode.
+              Without token, returns deterministic offline fixtures.
+              Set NERAJOB_FINDWORK_OFFLINE=1 to force offline even with token.
     """
     scrapers: list[BaseScraper] = [
         SampleScraper(),
@@ -41,6 +45,7 @@ def available_scrapers() -> dict[str, BaseScraper]:
         LeverScraper(board_name=os.getenv("NERAJOB_LEVER_BOARD") or None),
         AshbyScraper(board_id=os.getenv("NERAJOB_ASHBY_BOARD") or None),
         SmartRecruitersScraper(),
+        FindworkScraper(),
     ]
     return {s.name: s for s in scrapers}
 

--- a/tests/test_findwork.py
+++ b/tests/test_findwork.py
@@ -1,0 +1,312 @@
+"""Tests for the Findwork.dev scraper (issue #6)."""
+from __future__ import annotations
+
+import pytest
+
+from nerajob.scrapers.findwork import FindworkScraper
+from nerajob.scrapers.registry import available_scrapers, get_scraper
+
+
+def test_findwork_registered() -> None:
+    assert "findwork" in available_scrapers()
+
+
+def test_findwork_get_scraper_returns_findwork_instance() -> None:
+    scraper = get_scraper("findwork")
+    assert isinstance(scraper, FindworkScraper)
+    assert scraper.name == "findwork"
+
+
+def test_findwork_offline_returns_jobs(monkeypatch) -> None:
+    monkeypatch.delenv("NERAJOB_FINDWORK_API_TOKEN", raising=False)
+    monkeypatch.delenv("NERAJOB_FINDWORK_OFFLINE", raising=False)
+    jobs = get_scraper("findwork").search("python", limit=10)
+    assert jobs
+    assert all(j.source == "findwork" for j in jobs)
+
+
+def test_findwork_offline_explicit_env(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_OFFLINE", "1")
+    monkeypatch.setenv("NERAJOB_FINDWORK_API_TOKEN", "fake-token-ignored")
+    jobs = get_scraper("findwork").search("python", limit=5)
+    assert jobs
+    assert all(j.source == "findwork" for j in jobs)
+
+
+def test_findwork_offline_query_filter(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_OFFLINE", "1")
+    scraper = FindworkScraper()
+    python_jobs = scraper.search("python", limit=10)
+    rust_jobs = scraper.search("rust", limit=10)
+    assert len(python_jobs) >= 1
+    assert len(rust_jobs) == 0
+
+
+def test_findwork_offline_location_filter(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_OFFLINE", "1")
+    scraper = FindworkScraper()
+    eu_jobs = scraper.search("", location="EU", limit=10)
+    assert len(eu_jobs) >= 1
+    for j in eu_jobs:
+        assert "eu" in j.location.lower() or "remote" in j.location.lower()
+
+
+def test_findwork_offline_limit_enforced(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_OFFLINE", "1")
+    scraper = FindworkScraper()
+    jobs = scraper.search("", limit=2)
+    assert len(jobs) <= 2
+
+
+def test_findwork_offline_deterministic(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_OFFLINE", "1")
+    scraper = FindworkScraper()
+    run1 = scraper.search("python", limit=5)
+    run2 = scraper.search("python", limit=5)
+    assert len(run1) == len(run2)
+    for a, b in zip(run1, run2):
+        assert a.id == b.id
+        assert a.title == b.title
+
+
+def test_findwork_offline_returns_no_jobs_for_unknown_query(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_OFFLINE", "1")
+    scraper = FindworkScraper()
+    jobs = scraper.search("cobol", limit=10)
+    assert jobs == []
+
+
+def test_findwork_offline_returns_all_when_no_query(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_OFFLINE", "1")
+    scraper = FindworkScraper()
+    jobs = scraper.search("", limit=20)
+    assert len(jobs) == 5
+
+
+def test_findwork_offline_jobposting_fields(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_OFFLINE", "1")
+    scraper = FindworkScraper()
+    jobs = scraper.search("python", limit=1)
+    assert jobs
+    j = jobs[0]
+    assert j.id.startswith("findwork-")
+    assert j.source == "findwork"
+    assert j.title
+    assert j.company
+    assert j.location
+    assert j.url
+    assert j.description
+    assert isinstance(j.tags, list)
+    assert isinstance(j.remote, bool)
+
+
+@pytest.fixture
+def fake_findwork_api_response() -> dict:
+    return {
+        "count": 2,
+        "next": None,
+        "previous": None,
+        "results": [
+            {
+                "id": 12345,
+                "role": "Senior Python Engineer",
+                "company": {"name": "Findwork Live Co"},
+                "location": "Remote (Worldwide)",
+                "url": "https://findwork.dev/jobs/12345-senior-python-engineer/",
+                "text": "Build scalable Python services. FastAPI + PostgreSQL. Remote-first.",
+                "tags": ["python", "fastapi", "postgresql"],
+                "keywords": ["backend", "api"],
+                "remote": True,
+            },
+            {
+                "id": 67890,
+                "role": "DevOps Engineer",
+                "company_name": "Cloudward Live",
+                "location": "Remote (US)",
+                "url": "https://findwork.dev/jobs/67890-devops-engineer/",
+                "text": "Kubernetes, Terraform, AWS. On-call rotation every 6 weeks.",
+                "tags": ["kubernetes", "terraform", "aws"],
+                "keywords": ["devops", "sre"],
+                "remote": True,
+            },
+        ],
+    }
+
+
+def test_findwork_live_api_parses_results(monkeypatch, fake_findwork_api_response) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_API_TOKEN", "fake-token")
+    monkeypatch.delenv("NERAJOB_FINDWORK_OFFLINE", raising=False)
+    scraper = FindworkScraper()
+
+    class FakeResponse:
+        status_code = 200
+        def raise_for_status(self): pass
+        def json(self): return fake_findwork_api_response
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs): pass
+        def __enter__(self): return self
+        def __exit__(self, *args): return False
+        def get(self, url, params=None):
+            assert "findwork.dev" in url
+            return FakeResponse()
+
+    monkeypatch.setattr("nerajob.scrapers.findwork.httpx.Client", FakeClient)
+
+    jobs = scraper.search("python", limit=10)
+    assert len(jobs) == 1
+    assert all(j.source == "findwork" for j in jobs)
+    assert jobs[0].title == "Senior Python Engineer"
+    assert jobs[0].company == "Findwork Live Co"
+    assert jobs[0].remote is True
+    assert "python" in jobs[0].tags
+    assert jobs[0].id == "findwork-12345"
+
+
+def test_findwork_live_api_falls_back_on_error(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_API_TOKEN", "fake-token")
+    monkeypatch.delenv("NERAJOB_FINDWORK_OFFLINE", raising=False)
+    scraper = FindworkScraper()
+
+    class FailingClient:
+        def __init__(self, *args, **kwargs): pass
+        def __enter__(self): return self
+        def __exit__(self, *args): return False
+        def get(self, url, params=None):
+            raise ConnectionError("simulated network failure")
+
+    monkeypatch.setattr("nerajob.scrapers.findwork.httpx.Client", FailingClient)
+
+    jobs = scraper.search("python", limit=5)
+    assert jobs
+    assert all(j.source == "findwork" for j in jobs)
+
+
+def test_findwork_live_api_falls_back_on_403(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_API_TOKEN", "revoked-token")
+    monkeypatch.delenv("NERAJOB_FINDWORK_OFFLINE", raising=False)
+    scraper = FindworkScraper()
+
+    class ForbiddenResponse:
+        status_code = 403
+        def raise_for_status(self):
+            import httpx
+            raise httpx.HTTPStatusError(
+                "403 Forbidden",
+                request=httpx.Request("GET", "https://findwork.dev/api/jobs/"),
+                response=httpx.Response(403),
+            )
+        def json(self): return {"detail": "Invalid token."}
+
+    class ForbiddenClient:
+        def __init__(self, *args, **kwargs): pass
+        def __enter__(self): return self
+        def __exit__(self, *args): return False
+        def get(self, url, params=None): return ForbiddenResponse()
+
+    monkeypatch.setattr("nerajob.scrapers.findwork.httpx.Client", ForbiddenClient)
+
+    jobs = scraper.search("python", limit=5)
+    assert jobs
+
+
+def test_findwork_live_api_query_filter(monkeypatch, fake_findwork_api_response) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_API_TOKEN", "fake-token")
+    monkeypatch.delenv("NERAJOB_FINDWORK_OFFLINE", raising=False)
+    scraper = FindworkScraper()
+
+    class FakeResponse:
+        status_code = 200
+        def raise_for_status(self): pass
+        def json(self): return fake_findwork_api_response
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs): pass
+        def __enter__(self): return self
+        def __exit__(self, *args): return False
+        def get(self, url, params=None): return FakeResponse()
+
+    monkeypatch.setattr("nerajob.scrapers.findwork.httpx.Client", FakeClient)
+
+    python_jobs = scraper.search("python", limit=10)
+    assert len(python_jobs) == 1
+    assert python_jobs[0].title == "Senior Python Engineer"
+
+    kube_jobs = scraper.search("kubernetes", limit=10)
+    assert len(kube_jobs) == 1
+    assert kube_jobs[0].title == "DevOps Engineer"
+
+
+def test_findwork_live_api_skips_items_without_title(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_API_TOKEN", "fake-token")
+    monkeypatch.delenv("NERAJOB_FINDWORK_OFFLINE", raising=False)
+    scraper = FindworkScraper()
+
+    payload = {
+        "results": [
+            {"id": 1, "role": "Valid Job", "company_name": "Co"},
+            {"id": 2, "company_name": "No Title Co"},
+            {"id": 3, "role": "", "company_name": "Empty Title Co"},
+        ]
+    }
+
+    class FakeResponse:
+        status_code = 200
+        def raise_for_status(self): pass
+        def json(self): return payload
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs): pass
+        def __enter__(self): return self
+        def __exit__(self, *args): return False
+        def get(self, url, params=None): return FakeResponse()
+
+    monkeypatch.setattr("nerajob.scrapers.findwork.httpx.Client", FakeClient)
+
+    jobs = scraper.search("", limit=10)
+    assert len(jobs) == 1
+    assert jobs[0].title == "Valid Job"
+
+
+def test_findwork_company_fallback_to_unknown(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_API_TOKEN", "fake-token")
+    monkeypatch.delenv("NERAJOB_FINDWORK_OFFLINE", raising=False)
+    scraper = FindworkScraper()
+
+    payload = {
+        "results": [
+            {"id": 1, "role": "Mystery Job"},
+        ]
+    }
+
+    class FakeResponse:
+        status_code = 200
+        def raise_for_status(self): pass
+        def json(self): return payload
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs): pass
+        def __enter__(self): return self
+        def __exit__(self, *args): return False
+        def get(self, url, params=None): return FakeResponse()
+
+    monkeypatch.setattr("nerajob.scrapers.findwork.httpx.Client", FakeClient)
+
+    jobs = scraper.search("", limit=10)
+    assert len(jobs) == 1
+    assert jobs[0].company == "Unknown Company"
+
+
+def test_findwork_offline_posting_has_correct_id_prefix(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_OFFLINE", "1")
+    scraper = FindworkScraper()
+    jobs = scraper.search("python", limit=1)
+    assert jobs[0].id.startswith("findwork-")
+
+
+def test_findwork_offline_posting_remote_flag(monkeypatch) -> None:
+    monkeypatch.setenv("NERAJOB_FINDWORK_OFFLINE", "1")
+    scraper = FindworkScraper()
+    jobs = scraper.search("", limit=10)
+    for j in jobs:
+        assert j.remote is True


### PR DESCRIPTION
feat(scrapers): add Findwork.dev adapter with offline fallback

Fixes #6

## Summary

Implements FindworkScraper in src/nerajob/scrapers/findwork.py inheriting from BaseScraper. Connects to https://findwork.dev/api/jobs/ public REST API with Token auth.

## Architecture

- Live mode: requires NERAJOB_FINDWORK_API_TOKEN env var
- Offline mode: 5 deterministic fixtures (default when no token)
- Graceful degradation: API errors (network, 403, 429) fall back to offline
- Force offline: NERAJOB_FINDWORK_OFFLINE=1 overrides even with token

## Field Mapping

From Findwork API to JobPosting:
- id (int) -> findwork-{id}
- role (str) -> title
- company.name (nested) or company_name (flat) -> company
- location, url, text, tags, keywords, remote -> mapped directly
- Unknown Company fallback when both company fields missing
- Items missing title are skipped (not crash)

## Registration

Registered in src/nerajob/scrapers/registry.py available_scrapers().

## Tests

19 new tests in tests/test_findwork.py covering:
- Registration in scrapers registry
- Offline mode (default + forced)
- Query + location filtering
- Limit enforcement + determinism
- Live API (mocked httpx) parsing
- Live API failure -> offline fallback
- 403 Forbidden -> offline fallback
- Missing title skip
- Missing company fallback
- JobPosting field validation

Full suite: 112 passed (93 baseline + 19 new)
Ruff: clean

## MergeOS Claim

- Starred mergeos-bounties/NeraJob and mergeos-bounties/mergeos (org-wide Gate 1)
- Claim comment on issue #6
- Claim Token comment on mergeos#1