### PR TITLE
feat: add match --resume-file --jobs-file offline demo

### DIFF
--- a/demo/match_offline.py
+++ b/demo/match_offline.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Demo: nerajob match --resume-file --jobs-file offline matching.
+Matches resumes to jobs using local JSON files instead of live API."""
+
+import json, argparse, sys
+from pathlib import Path
+
+def load_json(path):
+    """Load a JSON file with error handling."""
+    try:
+        with open(path, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"Error: File not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON in {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+def match_skills(resume_skills, job_skills):
+    """Calculate skill match score."""
+    if not job_skills:
+        return 0.0
+    resume_set = set(s.lower() for s in resume_skills)
+    job_set = set(s.lower() for s in job_skills)
+    matches = resume_set & job_set
+    return len(matches) / len(job_set)
+
+def match_resume_to_jobs(resume, jobs):
+    """Score a single resume against all jobs."""
+    results = []
+    resume_skills = resume.get("skills", [])
+    for job in jobs:
+        score = match_skills(resume_skills, job.get("required_skills", []))
+        results.append({
+            "job_id": job.get("id", "unknown"),
+            "job_title": job.get("title", "Untitled"),
+            "company": job.get("company", "Unknown"),
+            "match_score": round(score, 2),
+            "matched_skills": [s for s in job.get("required_skills", [])
+                              if s.lower() in (rs.lower() for rs in resume_skills)]
+        })
+    results.sort(key=lambda x: x["match_score"], reverse=True)
+    return results
+
+def main():
+    parser = argparse.ArgumentParser(description="Match resumes to jobs offline")
+    parser.add_argument("--resume-file", required=True, help="Path to resume JSON file")
+    parser.add_argument("--jobs-file", required=True, help="Path to jobs JSON file")
+    parser.add_argument("--top", type=int, default=5, help="Show top N matches (default: 5)")
+    parser.add_argument("--output", "-o", help="Output file for results (JSON)")
+    args = parser.parse_args()
+
+    resume = load_json(args.resume_file)
+    jobs_data = load_json(args.jobs_file)
+    
+    # Support both {"jobs": [...]} and [...] formats
+    if isinstance(jobs_data, dict):
+        jobs = jobs_data.get("jobs", [])
+    elif isinstance(jobs_data, list):
+        jobs = jobs_data
+    else:
+        print("Error: jobs file must be a list or object with 'jobs' key", file=sys.stderr)
+        sys.exit(1)
+    
+    print(f"Loaded resume: {resume.get('name', 'Unknown')}")
+    print(f"Loaded {len(jobs)} job listings")
+    print(f"\nTop {min(args.top, len(jobs))} matches:")
+    print("-" * 60)
+    
+    matches = match_resume_to_jobs(resume, jobs)
+    
+    for i, m in enumerate(matches[:args.top]):
+        stars = "\u2605" * int(m["match_score"] * 5) if m["match_score"] > 0 else "No match"
+        print(f"{i+1}. {m['job_title']} @ {m['company']}")
+        print(f"   Score: {m['match_score']:.0%} {stars}")
+        if m["matched_skills"]:
+            print(f"   Skills: {', '.join(m['matched_skills'])}")
+        print()
+    
+    if args.output:
+        output_data = {
+            "resume": resume.get("name", "Unknown"),
+            "total_jobs": len(jobs),
+            "top_matches": matches[:args.top]
+        }
+        with open(args.output, 'w') as f:
+            json.dump(output_data, f, indent=2)
+        print(f"Results saved to {args.output}")
+
+if __name__ == "__main__":
+    main()

--- a/demo/samples/sample_jobs.json
+++ b/demo/samples/sample_jobs.json
@@ -1,0 +1,69 @@
+{
+  "jobs": [
+    {
+      "id": "job_001",
+      "title": "Senior Python Backend Developer",
+      "company": "DataFlow Inc",
+      "required_skills": [
+        "Python",
+        "Django",
+        "PostgreSQL",
+        "Docker",
+        "AWS"
+      ],
+      "description": "Build scalable backend services for data processing pipeline."
+    },
+    {
+      "id": "job_002",
+      "title": "Full Stack Developer",
+      "company": "WebStack Co",
+      "required_skills": [
+        "Python",
+        "React",
+        "TypeScript",
+        "PostgreSQL",
+        "Docker"
+      ],
+      "description": "Full stack development for SaaS platform."
+    },
+    {
+      "id": "job_003",
+      "title": "DevOps Engineer",
+      "company": "CloudOps Ltd",
+      "required_skills": [
+        "Docker",
+        "Kubernetes",
+        "AWS",
+        "Terraform",
+        "CI/CD"
+      ],
+      "description": "Manage cloud infrastructure and deployment pipelines."
+    },
+    {
+      "id": "job_004",
+      "title": "Data Engineer",
+      "company": "BigData Systems",
+      "required_skills": [
+        "Python",
+        "Spark",
+        "PostgreSQL",
+        "AWS",
+        "Airflow"
+      ],
+      "description": "Build and maintain data pipelines and ETL processes."
+    },
+    {
+      "id": "job_005",
+      "title": "Frontend Developer",
+      "company": "UI Masters",
+      "required_skills": [
+        "React",
+        "TypeScript",
+        "CSS",
+        "HTML",
+        "Figma"
+      ],
+      "description": "Build responsive web applications with modern frameworks."
+    }
+  ]
+}

--- a/demo/samples/sample_resume.json
+++ b/demo/samples/sample_resume.json
@@ -1,0 +1,29 @@
+{
+  "name": "Jane Developer",
+  "email": "jane@example.com",
+  "summary": "Senior Python developer with 5 years of experience in backend systems and data engineering.",
+  "skills": [
+    "Python",
+    "Django",
+    "FastAPI",
+    "PostgreSQL",
+    "Docker",
+    "AWS",
+    "Redis",
+    "Celery",
+    "Pytest",
+    "Git"
+  ],
+  "experience": [
+    {
+      "title": "Senior Backend Engineer",
+      "company": "TechCorp",
+      "years": 3
+    },
+    {
+      "title": "Backend Developer",
+      "company": "StartupX",
+      "years": 2
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Implements `nerajob match --resume-file --jobs-file` offline demo for CLI.

## Changes
- `demo/match_offline.py` — Full CLI tool for offline resume-to-job matching
  - `--resume-file`: Path to resume JSON (name, skills, experience)
  - `--jobs-file`: Path to jobs JSON (array of job listings with required_skills)
  - `--top N`: Show top N matches (default: 5)
  - `--output/-o`: Save results to JSON file
  - Skill-based scoring with case-insensitive matching
- `demo/samples/sample_resume.json` — Example resume for testing
- `demo/samples/sample_jobs.json` — 5 job listings for testing

## Usage
```bash
python demo/match_offline.py --resume-file demo/samples/sample_resume.json --jobs-file demo/samples/sample_jobs.json --top 3
```

Closes #54